### PR TITLE
Moving towards Easings enum class and deprecated most companion object methods

### DIFF
--- a/korma/src/commonMain/kotlin/com/soywiz/korma/interpolation/Easing.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/interpolation/Easing.kt
@@ -2,92 +2,160 @@ package com.soywiz.korma.interpolation
 
 import kotlin.math.*
 
+private inline fun combine(it: Double, start: Easing, end: Easing) =
+    if (it < 0.5) 0.5 * start(it * 2.0) else 0.5 * end((it - 0.5) * 2.0) + 0.5
+private const val BOUNCE_FACTOR = 1.70158
+private const val HALF_PI = PI / 2.0
+
 @Suppress("unused")
 fun interface Easing {
     operator fun invoke(it: Double): Double
 
     companion object {
         fun cubic(f: (t: Double, b: Double, c: Double, d: Double) -> Double): Easing = Easing { f(it, 0.0, 1.0, 1.0) }
-        fun combine(start: Easing, end: Easing) = Easing { if (it < 0.5) 0.5 * start(it * 2.0) else 0.5 * end((it - 0.5) * 2.0) + 0.5 }
+        fun combine(start: Easing, end: Easing) = Easing { combine(it, start, end) }
 
-        operator fun invoke(f: (Double) -> Double) = Easing { it -> f(it) }
+        operator fun invoke(f: (Double) -> Double) = Easing { f(it) }
 
-        val SMOOTH get() = Easings.SMOOTH
-        val EASE_IN_ELASTIC get() = Easings.EASE_IN_ELASTIC
-        val EASE_OUT_ELASTIC get() = Easings.EASE_OUT_ELASTIC
-        val EASE_OUT_BOUNCE get() = Easings.EASE_OUT_BOUNCE
-        val LINEAR get() = Easings.LINEAR
-        val EASE_IN get() = Easings.EASE_IN
-        val EASE_OUT get() = Easings.EASE_OUT
-        val EASE_IN_OUT get() = Easings.EASE_IN_OUT
-        val EASE_OUT_IN get() = Easings.EASE_OUT_IN
-        val EASE_IN_BACK get() = Easings.EASE_IN_BACK
-        val EASE_OUT_BACK get() = Easings.EASE_OUT_BACK
-        val EASE_IN_OUT_BACK get() = Easings.EASE_IN_OUT_BACK
-        val EASE_OUT_IN_BACK get() = Easings.EASE_OUT_IN_BACK
-        val EASE_IN_OUT_ELASTIC get() = Easings.EASE_IN_OUT_ELASTIC
-        val EASE_OUT_IN_ELASTIC get() = Easings.EASE_OUT_IN_ELASTIC
-        val EASE_IN_BOUNCE get() = Easings.EASE_IN_BOUNCE
-        val EASE_IN_OUT_BOUNCE get() = Easings.EASE_IN_OUT_BOUNCE
-        val EASE_OUT_IN_BOUNCE get() = Easings.EASE_OUT_IN_BOUNCE
-        val EASE_IN_QUAD get() = Easings.EASE_IN_QUAD
-        val EASE_OUT_QUAD get() = Easings.EASE_OUT_QUAD
-        val EASE_IN_OUT_QUAD get() = Easings.EASE_IN_OUT_QUAD
-        val EASE_SINE get() = Easings.EASE_SINE
+        /**
+         * Retrieves a mapping of all standard easings defined directly in [Easing], for example "SMOOTH" -> Easing.SMOOTH.
+         */
+        val ALL: Map<String, Easing> by lazy(LazyThreadSafetyMode.PUBLICATION) {
+            Easings.values().associateBy { it.name }
+        }
+
+        // Author's note:
+        // 1. Make sure new standard easings are added both here and in the Easings enum class
+        // 2. Make sure the name is the same, otherwise ALL_STANDARD will return confusing results
+
+        val SMOOTH: Easing get() = Easings.SMOOTH
+        val EASE_IN_ELASTIC: Easing get() = Easings.EASE_IN_ELASTIC
+        val EASE_OUT_ELASTIC: Easing get() = Easings.EASE_OUT_ELASTIC
+        val EASE_OUT_BOUNCE: Easing get() = Easings.EASE_OUT_BOUNCE
+        val LINEAR: Easing get() = Easings.LINEAR
+        val EASE_IN: Easing get() = Easings.EASE_IN
+        val EASE_OUT: Easing get() = Easings.EASE_OUT
+        val EASE_IN_OUT: Easing get() = Easings.EASE_IN_OUT
+        val EASE_OUT_IN: Easing get() = Easings.EASE_OUT_IN
+        val EASE_IN_BACK: Easing get() = Easings.EASE_IN_BACK
+        val EASE_OUT_BACK: Easing get() = Easings.EASE_OUT_BACK
+        val EASE_IN_OUT_BACK: Easing get() = Easings.EASE_IN_OUT_BACK
+        val EASE_OUT_IN_BACK: Easing get() = Easings.EASE_OUT_IN_BACK
+        val EASE_IN_OUT_ELASTIC: Easing get() = Easings.EASE_IN_OUT_ELASTIC
+        val EASE_OUT_IN_ELASTIC: Easing get() = Easings.EASE_OUT_IN_ELASTIC
+        val EASE_IN_BOUNCE: Easing get() = Easings.EASE_IN_BOUNCE
+        val EASE_IN_OUT_BOUNCE: Easing get() = Easings.EASE_IN_OUT_BOUNCE
+        val EASE_OUT_IN_BOUNCE: Easing get() = Easings.EASE_OUT_IN_BOUNCE
+        val EASE_IN_QUAD: Easing get() = Easings.EASE_IN_QUAD
+        val EASE_OUT_QUAD: Easing get() = Easings.EASE_OUT_QUAD
+        val EASE_IN_OUT_QUAD: Easing get() = Easings.EASE_IN_OUT_QUAD
+        val EASE_SINE: Easing get() = Easings.EASE_SINE
     }
 }
 
-private object Easings {
-    private const val BOUNCE_10 = 1.70158
-    private const val PI_2 = PI / 2.0
+private enum class Easings : Easing {
+    SMOOTH {
+        override fun invoke(it: Double): Double = it * it * (3 - 2 * it)
+    },
+    EASE_IN_ELASTIC {
+        override fun invoke(it: Double): Double =
+            if (it == 0.0 || it == 1.0) {
+                it
+            } else {
+                val p = 0.3
+                val s = p / 4.0
+                val inv = it - 1
 
-    val SMOOTH = Easing { it * it * (3 - 2 * it) }
-
-    val EASE_IN_ELASTIC = Easing {
-        if (it == 0.0 || it == 1.0) it else {
-            val p = 0.3
-            val s = p / 4.0
-            val inv = it - 1
-            -1.0 * 2.0.pow(10.0 * inv) * sin((inv - s) * (2.0 * PI) / p)
+                -1.0 * 2.0.pow(10.0 * inv) * sin((inv - s) * (2.0 * PI) / p)
+            }
+    },
+    EASE_OUT_ELASTIC {
+        override fun invoke(it: Double): Double =
+            if (it == 0.0 || it == 1.0) {
+                it
+            } else {
+                val p = 0.3
+                val s = p / 4.0
+                2.0.pow(-10.0 * it) * sin((it - s) * (2.0 * PI) / p) + 1
+            }
+    },
+    EASE_OUT_BOUNCE {
+        override fun invoke(it: Double): Double {
+            val s = 7.5625
+            val p = 2.75
+            return when {
+                it < 1.0 / p -> s * it.pow(2.0)
+                it < 2.0 / p -> s * (it - 1.5 / p).pow(2.0) + 0.75
+                it < 2.5 / p -> s * (it - 2.25 / p).pow(2.0) + 0.9375
+                else -> s * (it - 2.625 / p).pow(2.0) + 0.984375
+            }
         }
+    },
+    LINEAR {
+        override fun invoke(it: Double): Double = it
+    },
+    EASE_IN {
+        override fun invoke(it: Double): Double = it * it * it
+    },
+    EASE_OUT {
+        override fun invoke(it: Double): Double =
+            (it - 1.0).let { inv ->
+                inv * inv * inv + 1
+            }
+    },
+    EASE_IN_OUT {
+        override fun invoke(it: Double): Double = combine(it, EASE_IN, EASE_OUT)
+    },
+    EASE_OUT_IN {
+        override fun invoke(it: Double): Double = combine(it, EASE_OUT, EASE_IN)
+    },
+    EASE_IN_BACK {
+        override fun invoke(it: Double): Double = it.pow(2.0) * ((BOUNCE_FACTOR + 1.0) * it - BOUNCE_FACTOR)
+    },
+    EASE_OUT_BACK {
+        override fun invoke(it: Double): Double =
+            (it - 1.0).let { inv ->
+                inv.pow(2.0) * ((BOUNCE_FACTOR + 1.0) * inv + BOUNCE_FACTOR) + 1.0
+            }
+    },
+    EASE_IN_OUT_BACK {
+        override fun invoke(it: Double): Double = combine(it, EASE_IN_BACK, EASE_OUT_BACK)
+    },
+    EASE_OUT_IN_BACK {
+        override fun invoke(it: Double): Double = combine(it, EASE_OUT_BACK, EASE_IN_BACK)
+    },
+    EASE_IN_OUT_ELASTIC {
+        override fun invoke(it: Double): Double = combine(it, EASE_IN_ELASTIC, EASE_OUT_ELASTIC)
+    },
+    EASE_OUT_IN_ELASTIC {
+        override fun invoke(it: Double): Double = combine(it, EASE_OUT_ELASTIC, EASE_IN_ELASTIC)
+    },
+    EASE_IN_BOUNCE {
+        override fun invoke(it: Double): Double = 1.0 - EASE_OUT_BOUNCE(1.0 - it)
+    },
+    EASE_IN_OUT_BOUNCE {
+        override fun invoke(it: Double): Double = combine(it, EASE_IN_BOUNCE, EASE_OUT_BOUNCE)
+    },
+    EASE_OUT_IN_BOUNCE {
+        override fun invoke(it: Double): Double = combine(it, EASE_OUT_BOUNCE, EASE_IN_BOUNCE)
+    },
+    EASE_IN_QUAD {
+        override fun invoke(it: Double): Double = 1.0 * it * it
+    },
+    EASE_OUT_QUAD {
+        override fun invoke(it: Double): Double = -1.0 * it * (it - 2)
+    },
+    EASE_IN_OUT_QUAD {
+        override fun invoke(it: Double): Double =
+            (it * 2.0).let { t ->
+                if (t < 1) {
+                    1.0 / 2 * t * t
+                } else {
+                    -1.0 / 2 * ((t - 1) * ((t - 1) - 2) - 1)
+                }
+            }
+    },
+    EASE_SINE {
+        override fun invoke(it: Double): Double = sin(it * HALF_PI)
     }
-
-    val EASE_OUT_ELASTIC = Easing {
-        if (it == 0.0 || it == 1.0) it else {
-            val p = 0.3
-            val s = p / 4.0
-            2.0.pow(-10.0 * it) * sin((it - s) * (2.0 * PI) / p) + 1
-        }
-    }
-
-    val EASE_OUT_BOUNCE = Easing {
-        val s = 7.5625
-        val p = 2.75
-        when {
-            it < (1.0 / p) -> s * it.pow(2.0)
-            it < (2.0 / p) -> s * (it - 1.5 / p).pow(2.0) + 0.75
-            it < 2.5 / p -> s * (it - 2.25 / p).pow(2.0) + 0.9375
-            else -> s * (it - 2.625 / p).pow(2.0) + 0.984375
-        }
-    }
-
-    val LINEAR = Easing { it }
-    val EASE_IN = Easing { it * it * it }
-    val EASE_OUT = Easing { val inv = it - 1.0; inv * inv * inv + 1 }
-    val EASE_IN_OUT = Easing.combine(EASE_IN, EASE_OUT)
-    val EASE_OUT_IN = Easing.combine(EASE_OUT, EASE_IN)
-    val EASE_IN_BACK = Easing { it.pow(2.0) * ((BOUNCE_10 + 1.0) * it - BOUNCE_10) }
-    val EASE_OUT_BACK = Easing { val inv = it - 1.0; inv.pow(2.0) * ((BOUNCE_10 + 1.0) * inv + BOUNCE_10) + 1.0 }
-    val EASE_IN_OUT_BACK = Easing.combine(EASE_IN_BACK, EASE_OUT_BACK)
-    val EASE_OUT_IN_BACK = Easing.combine(EASE_OUT_BACK, EASE_IN_BACK)
-    val EASE_IN_OUT_ELASTIC = Easing.combine(EASE_IN_ELASTIC, EASE_OUT_ELASTIC)
-    val EASE_OUT_IN_ELASTIC = Easing.combine(EASE_OUT_ELASTIC, EASE_IN_ELASTIC)
-    val EASE_IN_BOUNCE = Easing { 1.0 - EASE_OUT_BOUNCE(1.0 - it) }
-    val EASE_IN_OUT_BOUNCE = Easing.combine(EASE_IN_BOUNCE, EASE_OUT_BOUNCE)
-    val EASE_OUT_IN_BOUNCE = Easing.combine(EASE_OUT_BOUNCE, EASE_IN_BOUNCE)
-    val EASE_IN_QUAD = Easing { 1.0 * it * it }
-    val EASE_OUT_QUAD = Easing { -1.0 * it * (it - 2) }
-    val EASE_IN_OUT_QUAD = Easing { val t = it * 2.0; if (t < 1) (1.0 / 2 * t * t) else (-1.0 / 2 * ((t - 1) * ((t - 1) - 2) - 1)) }
-
-    val EASE_SINE = Easing { sin(it * PI_2) }
 }

--- a/korma/src/commonTest/kotlin/com/soywiz/korma/interpolation/EasingTest.kt
+++ b/korma/src/commonTest/kotlin/com/soywiz/korma/interpolation/EasingTest.kt
@@ -1,5 +1,6 @@
 package com.soywiz.korma.interpolation
 
+import kotlin.math.abs
 import kotlin.test.*
 
 class EasingTest {
@@ -25,5 +26,21 @@ class EasingTest {
     fun testSine() {
         assertEquals(0.0, Easing.EASE_SINE(0.0))
         assertEquals(1.0, Easing.EASE_SINE(1.0))
+    }
+
+    @Test
+    fun testStartsAtZero() {
+        Easing.ALL.values.forEach { easing ->
+            val v = easing(0.0)
+            assertTrue(abs(v) < 0.0001, "Easing $easing did not start at 0, was $v")
+        }
+    }
+
+    @Test
+    fun testEndsAtOne() {
+        Easing.ALL.values.forEach { easing ->
+            val v = easing(1.0)
+            assertTrue(abs(v - 1.0) < 0.0001, "Easing $easing did not end at 1, was $v")
+        }
     }
 }


### PR DESCRIPTION
This is a follow-up to [this post](https://forum.korge.org/topic/30/why-is-korma-s-easing-interface-not-an-enum/2).

There are a couple drawbacks with the current implementation that would be nice to address:
1. Every easing is duplicated between the public `Easing` companion object and the private `Easings` object.
2. It's hard to enumerate through all predefined easings, which is technically possible to do with reflection, but trivial with an enum.

Solving the first item isn't really possible without breaking compatibility, which isn't worth it for this level of minor change IMO.

And this PR does solve the second issue, which I use to write the test I originally wanted.

I'm not 100% sure it's worth merging this change, but I think the

```kotlin
interface Foo {
}
enum class Foos : Foo {
}
```

pattern is a good pattern to follow, in general.