### PR TITLE
Migration helpers as inline fun with @Deprecated

### DIFF
--- a/korge/src/commonMain/kotlin/migrate/migrate_klock_hr.kt
+++ b/korge/src/commonMain/kotlin/migrate/migrate_klock_hr.kt
@@ -1,0 +1,60 @@
+@file:Suppress(
+    "PackageDirectoryMismatch", "EXPERIMENTAL_API_USAGE", "unused", "UNUSED_PARAMETER",
+    "RedundantVisibilityModifier", "SpellCheckingInspection"
+)
+
+package com.soywiz.klock.hr
+
+import com.soywiz.klock.TimeSpan
+
+/**
+ * Migrate from version 1.15.1 to 2.0.0
+ */
+@Deprecated(
+    message = "Need migrate to milliseconds",
+    replaceWith = ReplaceWith("this.milliseconds", "com.soywiz.klock.milliseconds"),
+    level = DeprecationLevel.ERROR
+)
+public inline val Int.hrMilliseconds: TimeSpan
+    get() {
+        throw Error("migrate to milliseconds")
+    }
+
+/**
+ * Migrate from version 1.15.1 to 2.0.0
+ */
+@Deprecated(
+    message = "Need migrate to milliseconds",
+    replaceWith = ReplaceWith("this.milliseconds", "com.soywiz.klock.milliseconds"),
+    level = DeprecationLevel.ERROR
+)
+inline val Long.hrMilliseconds: TimeSpan
+    get() {
+        throw Error("migrate to milliseconds")
+    }
+
+/**
+ * Migrate from version 1.15.1 to 2.0.0
+ */
+@Deprecated(
+    message = "Need migrate to milliseconds",
+    replaceWith = ReplaceWith("this.milliseconds", "com.soywiz.klock.milliseconds"),
+    level = DeprecationLevel.ERROR
+)
+public inline val Float.hrMilliseconds: TimeSpan
+    get() {
+        throw Error("migrate to milliseconds")
+    }
+
+/**
+ * Migrate from version 1.15.1 to 2.0.0
+ */
+@Deprecated(
+    message = "Need migrate to milliseconds",
+    replaceWith = ReplaceWith("this.milliseconds", "com.soywiz.klock.milliseconds"),
+    level = DeprecationLevel.ERROR
+)
+public inline val Double.hrMilliseconds: TimeSpan
+    get() {
+        throw Error("migrate to milliseconds")
+    }

--- a/korge/src/commonMain/kotlin/migrate/migrate_korge_input.kt
+++ b/korge/src/commonMain/kotlin/migrate/migrate_korge_input.kt
@@ -1,0 +1,28 @@
+@file:Suppress("PackageDirectoryMismatch", "EXPERIMENTAL_API_USAGE", "unused", "UNUSED_PARAMETER",
+    "RedundantVisibilityModifier"
+)
+package com.soywiz.korge.input
+
+/**
+ * Migrate from version 1.15.1 to 2.0.0
+ */
+@Deprecated(
+    message = "Need migrate to down{...}",
+    replaceWith = ReplaceWith("down(callback)"),
+    level = DeprecationLevel.ERROR
+)
+public inline fun KeysEvents.onKeyDown(crossinline callback: suspend (com.soywiz.korev.KeyEvent) -> Unit): com.soywiz.korio.lang.Closeable {
+    throw Error("migrate KeysEvents.onKeyDown")
+}
+
+/**
+ * Migrate from version 1.15.1 to 2.0.0
+ */
+@Deprecated(
+    message = "Need migrate to up{...}",
+    replaceWith = ReplaceWith("up(callback)"),
+    level = DeprecationLevel.ERROR
+)
+public inline fun KeysEvents.onKeyUp(crossinline callback: suspend (com.soywiz.korev.KeyEvent) -> Unit): com.soywiz.korio.lang.Closeable {
+    throw Error("migrate KeysEvents.up")
+}

--- a/korge/src/commonMain/kotlin/migrate/migrate_korge_particle.kt
+++ b/korge/src/commonMain/kotlin/migrate/migrate_korge_particle.kt
@@ -1,0 +1,16 @@
+@file:Suppress("PackageDirectoryMismatch", "EXPERIMENTAL_API_USAGE", "unused", "UNUSED_PARAMETER",
+    "RedundantSuspendModifier", "RedundantVisibilityModifier"
+)
+package com.soywiz.korge.particle
+
+import com.soywiz.korio.file.VfsFile
+
+@Deprecated(
+    message = "Need migrate to readParticleEmitter()",
+    replaceWith = ReplaceWith("readParticleEmitter()"),
+    level = DeprecationLevel.ERROR
+)
+public suspend inline fun VfsFile.readParticle(): ParticleEmitter {
+    throw Error("migrate readParticle")
+}
+

--- a/korge/src/commonMain/kotlin/migrate/migrate_korge_view.kt
+++ b/korge/src/commonMain/kotlin/migrate/migrate_korge_view.kt
@@ -1,0 +1,61 @@
+@file:Suppress("RedundantVisibilityModifier", "unused", "PackageDirectoryMismatch", "UNUSED_PARAMETER")
+
+package com.soywiz.korge.view
+
+import com.soywiz.klock.TimeSpan
+import com.soywiz.korim.bitmap.BmpSlice
+import com.soywiz.korio.lang.Cancellable
+import com.soywiz.korma.geom.Angle
+
+/**
+ * Migrate from version 1.15.1 to 2.0.0
+ */
+@Deprecated(
+    message = "Need migrate to addUpdater()",
+    replaceWith = ReplaceWith("addUpdater(updatable)"),
+    level = DeprecationLevel.ERROR
+)
+public inline fun <T : View> T.addHrUpdater(updatable: T.(dt: TimeSpan) -> Unit): Cancellable {
+    throw Error("migrate addHrUpdater")
+}
+
+/**
+ * Migrate from version 1.15.1 to 2.0.0
+ */
+@Deprecated(
+    message = "Need migrate to rotation",
+    replaceWith = ReplaceWith("rotation"),
+    level = DeprecationLevel.ERROR
+)
+public inline var View.rotationDegrees: Angle
+    get() {
+        throw Error("migrate rotationDegrees")
+    }
+    set(v) {
+        throw Error("migrate rotationDegrees")
+    }
+
+/**
+ * Migrate from version 1.15.1 to 2.0.0
+ */
+@property:Deprecated(
+    message = "Need migrate to smoothing",
+    replaceWith = ReplaceWith("smoothing"),
+    level = DeprecationLevel.ERROR
+)
+public inline var Text.filtering: Boolean
+    get() = throw Error("migrate filtering")
+    set(value) = throw Error("migrate filtering")
+
+/**
+ * Migrate from version 1.15.1 to 2.0.0
+ */
+@property:Deprecated(
+    message = "Need migrate to bitmap",
+    replaceWith = ReplaceWith("bitmap"),
+    level = DeprecationLevel.ERROR
+)
+public inline var BaseImage.texture: BmpSlice
+    get() = throw Error("migrate texture")
+    set(value) = throw Error("migrate texture")
+

--- a/korge/src/commonMain/kotlin/migrate/migrate_view_filter.kt
+++ b/korge/src/commonMain/kotlin/migrate/migrate_view_filter.kt
@@ -1,0 +1,17 @@
+@file:Suppress("RedundantVisibilityModifier", "unused", "PackageDirectoryMismatch", "UNUSED_PARAMETER",
+    "RemoveSetterParameterType"
+)
+
+package com.soywiz.korge.view.filter
+
+/**
+ * Migrate from version 1.15.1 to 2.0.0
+ */
+@property:Deprecated(
+    message = "Need migrate to blendRation",
+    replaceWith = ReplaceWith("ratio"),
+    level = DeprecationLevel.ERROR
+)
+var TransitionFilter.blendRatio: Double
+    get() = throw Error("migrate blendRatio")
+    set(value: Double) = throw Error("migrate blendRatio")


### PR DESCRIPTION
Add migration helper functions in one directory korge/src/commonMain/kotlin/migrate. Files inside have different packages.
This is not the whole work. Just for now what I have already done.
Since these are not regular functions, I chose such filenames, for example "migrate_korge_view.kt".

Maybe better to put into different directories? (same as package)
