### PR TITLE
Backport changes from korge (0efd90cb5cb03f708a4127b69f66985d30ed2df7)

### DIFF
--- a/korge-dragonbones/src/commonMain/kotlin/com/soywiz/korge/dragonbones/KorgeDbArmatureDisplay.kt
+++ b/korge-dragonbones/src/commonMain/kotlin/com/soywiz/korge/dragonbones/KorgeDbArmatureDisplay.kt
@@ -309,7 +309,7 @@ class KorgeDbArmatureDisplay : Container(), IArmatureProxy {
     val animationNames get() = animation.animationNames
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection("DragonBones") {
+        container.uiCollapsibleSection("DragonBones") {
             addChild(UiRowEditableValue(app, "animation", UiListEditableValue(app, { animationNames }, ObservableProperty(
                 name = "animation",
                 internalSet = { animationName -> animation.play(animationName) },

--- a/korge-dragonbones/src/commonMain/kotlin/com/soywiz/korge/dragonbones/KorgeDbRef.kt
+++ b/korge-dragonbones/src/commonMain/kotlin/com/soywiz/korge/dragonbones/KorgeDbRef.kt
@@ -23,7 +23,7 @@ class KorgeDbRef() : Container(), ViewLeaf, ViewFileRef by ViewFileRef.Mixin() {
     }
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection("DragonBones") {
+        container.uiCollapsibleSection("DragonBones") {
             uiEditableValue(::sourceFile, kind = UiTextEditableValue.Kind.FILE(views.currentVfs) {
                 it.extensionLC == "dbbin" || it.baseName.endsWith("_ske.json")
             })

--- a/korge-spine/src/commonMain/kotlin/com/esotericsoftware/spine/korge/SkeletonView.kt
+++ b/korge-spine/src/commonMain/kotlin/com/esotericsoftware/spine/korge/SkeletonView.kt
@@ -336,7 +336,7 @@ class SkeletonView(val skeleton: Skeleton, val animationState: AnimationState?) 
     val currentMainAnimation get() = animationState?.tracks?.first()?.animation
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection("Animation") {
+        container.uiCollapsibleSection("Animation") {
             addChild(UiRowEditableValue(app, "animation", UiListEditableValue(app, { skeleton.data.animations.map { it.name } }, ObservableProperty(
                 name = "animation",
                 internalSet = {  animationName ->

--- a/korge-spine/src/commonMain/kotlin/com/esotericsoftware/spine/korge/SpineViewRef.kt
+++ b/korge-spine/src/commonMain/kotlin/com/esotericsoftware/spine/korge/SpineViewRef.kt
@@ -49,7 +49,7 @@ class SpineViewRef() : Container(), ViewLeaf, ViewFileRef by ViewFileRef.Mixin()
     }
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection("Spine") {
+        container.uiCollapsibleSection("Spine") {
             uiEditableValue(::sourceFile, kind = UiTextEditableValue.Kind.FILE(views.currentVfs) {
                 it.extensionLC == "skel"
             })

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/animate/Animate.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/animate/Animate.kt
@@ -131,7 +131,7 @@ abstract class AnBaseShape(final override val library: AnLibrary, final override
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
         val view = this
-        container.uiCollapsableSection("AnBaseShape") {
+        container.uiCollapsibleSection("AnBaseShape") {
             uiEditableValue(Pair(view::dxDouble, view::dyDouble), name = "dxy", clamp = false)
             button("Center") {
                 view.dx = (-view.width / 2).toFloat()
@@ -227,7 +227,7 @@ class AnTextField(override val library: AnLibrary, override val symbol: AnTextFi
 	override fun createInstance(): View = symbol.create(library) as View
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection("AnTextField") {
+        container.uiCollapsibleSection("AnTextField") {
             uiEditableValue(::text)
         }
         super.buildDebugComponent(views, container)
@@ -453,7 +453,7 @@ class AnMovieClip(override val library: AnLibrary, override val symbol: AnSymbol
 
 		//println("::::")
 
-        forEachChildrenWithIndex { depth, child ->
+        forEachChildWithIndex { depth: Int, child: View ->
 			val maskDepth = maskPushDepths.getOrElse(depth) { -1 }
 
 			// Push Mask
@@ -500,7 +500,7 @@ class AnMovieClip(override val library: AnLibrary, override val symbol: AnSymbol
 			//println("  " + ctx.batch.colorMask)
 		}
 
-		// Reset stencil
+        // Reset stencil
 		if (usedStencil && ctx.stencilIndex <= 0) {
 			//println("ctx.stencilIndex: ${ctx.stencilIndex}")
 			ctx.stencilIndex = 0
@@ -580,7 +580,7 @@ class AnMovieClip(override val library: AnLibrary, override val symbol: AnSymbol
     }
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection("SWF") {
+        container.uiCollapsibleSection("SWF") {
             addChild(UiRowEditableValue(app, "symbol", UiListEditableValue(app, { library.symbolsByName.keys.toList() }, ObservableProperty(
                 name = "symbol",
                 internalSet = { symbolName ->

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/debug/UiCollapsibleSection.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/debug/UiCollapsibleSection.kt
@@ -5,14 +5,23 @@ import com.soywiz.korim.color.*
 import com.soywiz.korma.geom.*
 import com.soywiz.korui.*
 
-fun UiContainer.uiCollapsableSection(name: String?, block: UiContainer.() -> Unit): UiCollapsableSection {
-    return UiCollapsableSection(app, name, block).also { addChild(it) }
+fun UiContainer.uiCollapsibleSection(name: String?, block: UiContainer.() -> Unit): UiCollapsibleSection {
+    return UiCollapsibleSection(app, name, block).also { addChild(it) }
 }
 
-class UiCollapsableSection(app: UiApplication, val name: String?, val componentChildren: List<UiComponent>) : UiContainer(app) {
+@Deprecated(
+    message = "An older name of `uiCollapsibleSection`",
+    replaceWith = ReplaceWith("uiCollapsibleSection(name, block)"),
+    level = DeprecationLevel.WARNING
+)
+fun UiContainer.uiCollapsableSection(name: String?, block: UiContainer.() -> Unit): UiCollapsibleSection {
+    return UiCollapsibleSection(app, name, block).also { addChild(it) }
+}
+
+class UiCollapsibleSection(app: UiApplication, val name: String?, val componentChildren: List<UiComponent>) : UiContainer(app) {
     companion object {
-        operator fun invoke(app: UiApplication, name: String?, block: UiContainer.() -> Unit): UiCollapsableSection =
-            UiCollapsableSection(app, name, listOf()).also { block(it.mycontainer) }
+        operator fun invoke(app: UiApplication, name: String?, block: UiContainer.() -> Unit): UiCollapsibleSection =
+            UiCollapsibleSection(app, name, listOf()).also { block(it.mycontainer) }
 
         private fun createIcon(angle: Angle): NativeImage {
             return NativeImage(ICON_SIZE, ICON_SIZE).context2d {
@@ -55,3 +64,9 @@ class UiCollapsableSection(app: UiApplication, val name: String?, val componentC
         }
     }
 }
+
+@Deprecated(
+    message = "An older spelling of UiCollapsableSection",
+    replaceWith = ReplaceWith("UiCollapsibleSection")
+)
+typealias UiCollapsableSection = UiCollapsibleSection

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/internal/KorgeInternal.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/internal/KorgeInternal.kt
@@ -1,5 +1,5 @@
 package com.soywiz.korge.internal
 
-/** A mechanism to annotate Korge internal properties and methods that left open in KorGE 1.0 to they can be marked as internal in KorGE 2.0 */
+/** A mechanism to annotate Korge internal properties and methods that were left open in KorGE 1.0 so they can be marked as internal in KorGE 2.0 */
 @RequiresOptIn(level = RequiresOptIn.Level.WARNING)
 annotation class KorgeInternal

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/particle/ParticleEmitterView.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/particle/ParticleEmitterView.kt
@@ -129,7 +129,7 @@ class ParticleEmitterView(emitter: ParticleEmitter, emitterPos: IPoint = IPoint(
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
         if (views.name == "ktree") {
-            container.uiCollapsableSection("Particle Emitter Reference") {
+            container.uiCollapsibleSection("Particle Emitter Reference") {
                 uiEditableValue(::sourceFile, UiTextEditableValue.Kind.FILE(views.currentVfs) {
                     it.extensionLC == "pex"
                 })
@@ -137,27 +137,27 @@ class ParticleEmitterView(emitter: ParticleEmitter, emitterPos: IPoint = IPoint(
             return
         }
         val particle = this@ParticleEmitterView.emitter
-        container.uiCollapsableSection("Particle Emitter") {
+        container.uiCollapsibleSection("Particle Emitter") {
             uiEditableValue(::texture, UiTextEditableValue.Kind.FILE(views.currentVfs) {
                 it.extensionLC == "png" || it.extensionLC == "jpg"
             })
             uiEditableValue(particle::emitterType, values = { ParticleEmitter.Type.values().toList() })
             uiEditableValue(particle::blendFuncSource, values = { AG.BlendFactor.values().toList() })
             uiEditableValue(particle::blendFuncDestination, values = { AG.BlendFactor.values().toList() })
-            uiCollapsableSection("Angle") {
+            uiCollapsibleSection("Angle") {
                 uiEditableValue(listOf(particle::angle, particle::angleVariance))
             }
-            uiCollapsableSection("Speed") {
+            uiCollapsibleSection("Speed") {
                 uiEditableValue(listOf(particle::speed, particle::speedVariance), 0.0, 1000.0)
             }
-            uiCollapsableSection("Lifespan") {
+            uiCollapsibleSection("Lifespan") {
                 uiEditableValue(listOf(particle::lifeSpan, particle::lifespanVariance), -10.0, 10.0)
                 uiEditableValue(particle::duration, -10.0, 10.0)
             }
             uiEditableValue("Gravity", particle.gravity)
             uiEditableValue("Source Position", particle.sourcePosition)
             uiEditableValue("Source Position Variance", particle.sourcePositionVariance)
-            uiCollapsableSection("Acceleration") {
+            uiCollapsibleSection("Acceleration") {
                 uiEditableValue(listOf(particle::radialAcceleration, particle::radialAccelVariance), -1000.0, +1000.0)
                 uiEditableValue(listOf(particle::tangentialAcceleration, particle::tangentialAccelVariance), -1000.0, +1000.0)
             }
@@ -169,11 +169,11 @@ class ParticleEmitterView(emitter: ParticleEmitter, emitterPos: IPoint = IPoint(
             uiEditableValue(listOf(particle::startSize, particle::startSizeVariance), -1000.0, +1000.0)
             uiEditableValue(listOf(particle::endSize, particle::endSizeVariance), -1000.0, 1000.0)
 
-            uiCollapsableSection("Radius") {
+            uiCollapsibleSection("Radius") {
                 uiEditableValue(listOf(particle::minRadius, particle::minRadiusVariance), min = -1000.0, max = 1000.0)
                 uiEditableValue(listOf(particle::maxRadius, particle::maxRadiusVariance), min = -1000.0, max = 1000.0)
             }
-            uiCollapsableSection("Rotate") {
+            uiCollapsibleSection("Rotate") {
                 uiEditableValue(listOf(particle::rotatePerSecond, particle::rotatePerSecondVariance))
                 uiEditableValue(listOf(particle::rotationStart, particle::rotationStartVariance))
                 uiEditableValue(listOf(particle::rotationEnd, particle::rotationEndVariance))

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/tiled/TiledMapViewRef.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/tiled/TiledMapViewRef.kt
@@ -19,7 +19,7 @@ class TiledMapViewRef() : Container(), ViewLeaf, ViewFileRef by ViewFileRef.Mixi
     }
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection("TiledMap") {
+        container.uiCollapsibleSection("TiledMap") {
             uiEditableValue(::sourceFile, kind = UiTextEditableValue.Kind.FILE(views.currentVfs) {
                 it.extensionLC == "tmx"
             })

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UICheckBox.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UICheckBox.kt
@@ -117,7 +117,7 @@ open class UICheckBox(
     }
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection(UICheckBox::class.simpleName!!) {
+        container.uiCollapsibleSection(UICheckBox::class.simpleName!!) {
             uiEditableValue(::text)
             uiEditableValue(::checked)
         }

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIComboBox.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIComboBox.kt
@@ -77,11 +77,11 @@ open class UIComboBox<T>(
     }
 
 	private fun updateItemsSize() {
-		itemsView.container.forEachChildrenWithIndex { index, child ->
-			child.height = itemHeight.toDouble()
-			child.position(0, index * itemHeight)
-		}
-	}
+        itemsView.container.forEachChildWithIndex { index: Int, child: View ->
+            child.height = itemHeight.toDouble()
+            child.position(0, index * itemHeight)
+        }
+    }
 
 	private fun updateItems() {
 		itemsView.container.removeChildren()

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIProgressBar.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UIProgressBar.kt
@@ -53,7 +53,7 @@ open class UIProgressBar(
 	}
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection(this@UIProgressBar::class.simpleName!!) {
+        container.uiCollapsibleSection(this@UIProgressBar::class.simpleName!!) {
             uiEditableValue(::current, min = 0.0, max = 100.0, clamp = false)
             uiEditableValue(::maximum, min = 1.0, max = 100.0, clamp = false)
         }

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UITextButton.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/ui/UITextButton.kt
@@ -74,7 +74,7 @@ open class UITextButton(
 	}
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection(UITextButton::class.simpleName!!) {
+        container.uiCollapsibleSection(UITextButton::class.simpleName!!) {
             uiEditableValue(::text)
             uiEditableValue(::textSize, min = 1.0, max = 300.0)
             /*

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/AnimationViewRef.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/AnimationViewRef.kt
@@ -19,7 +19,7 @@ class AnimationViewRef() : Container(), ViewLeaf, ViewFileRef by ViewFileRef.Mix
     }
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection("SWF") {
+        container.uiCollapsibleSection("SWF") {
             uiEditableValue(::sourceFile, kind = UiTextEditableValue.Kind.FILE(views.currentVfs) {
                 it.extensionLC == "swf" || it.extensionLC == "ani"
             })

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Container.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Container.kt
@@ -16,8 +16,9 @@ inline fun Container.container(callback: @ViewDslMarker Container.() -> Unit = {
 /**
  * A simple container of [View]s.
  *
- * All the [children] in this container has an associated index that determines its rendering order.
- * The first child is rendered first, and the last, last. So when the childs are overlapping, the last child will overlap the previous ones.
+ * All the [children] in this container have an associated index that determines their rendering order.
+ * The first child is rendered first, and the last one is rendered last. So when children are overlapping with each other,
+ * the last child will overlap the previous ones.
  *
  * You can access the children by [numChildren], [getChildAt] or [size] and [get].
  *
@@ -35,7 +36,7 @@ open class Container : View(true) {
 	/**
 	 * Retrieves all the child [View]s.
      * Shouldn't be used if possible. You can use [numChildren] and [getChildAt] to get the children.
-     * You can also use [forEachChildren], [forEachChildrenWithIndex] and [forEachChildrenReversed] to iterate children
+     * You can also use [forEachChild], [forEachChildWithIndex] and [forEachChildReversed] to iterate children
 	 */
     @KorgeInternal
     val children: List<View> get() = childrenInternal
@@ -48,7 +49,7 @@ open class Container : View(true) {
     /** Sorts all the children by using the specified [comparator]. */
     fun sortChildrenBy(comparator: Comparator<View>) {
         _children?.sortWith(comparator)
-        forEachChildrenWithIndex { index, child ->
+        forEachChildWithIndex { index: Int, child: View ->
             child.index = index
         }
     }
@@ -202,13 +203,13 @@ open class Container : View(true) {
 	private val tempMatrix = Matrix()
 	override fun renderInternal(ctx: RenderContext) {
 		if (!visible) return
-		forEachChildren { child ->
+		forEachChild { child: View ->
 			child.render(ctx)
 		}
-	}
+    }
 
     override fun renderDebug(ctx: RenderContext) {
-        forEachChildren { child ->
+        forEachChild { child: View ->
             child.renderDebug(ctx)
         }
         super.renderDebug(ctx)
@@ -219,11 +220,11 @@ open class Container : View(true) {
 
 	override fun getLocalBoundsInternal(out: Rectangle) {
 		bb.reset()
-		forEachChildren { child ->
+		forEachChild { child: View ->
 			child.getBounds(this, tempRect)
 			bb.add(tempRect)
 		}
-		bb.getBounds(out)
+        bb.getBounds(out)
 	}
 
 	/**

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Image.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Image.kt
@@ -110,7 +110,7 @@ class Image(
     }
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection("Image") {
+        container.uiCollapsibleSection("Image") {
             uiEditableValue(this@Image::sourceFile, kind = UiTextEditableValue.Kind.FILE(views.currentVfs) {
                 it.extensionLC == "png" || it.extensionLC == "jpg"
             })

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/MaskedView.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/MaskedView.kt
@@ -28,7 +28,7 @@ class MaskedView : Container() {
                 setMaskState(ctx, MaskStates.STATE_CONTENT)
             }
 
-            forEachChildren { child ->
+            forEachChild { child: View ->
                 if (child != mask) {
                     child.render(ctx)
                 }

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/NinePatchEx.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/NinePatchEx.kt
@@ -176,7 +176,7 @@ class NinePatchEx(
     }
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection("9-PatchImage") {
+        container.uiCollapsibleSection("9-PatchImage") {
             uiEditableValue(::sourceFile, kind = UiTextEditableValue.Kind.FILE(views.currentVfs) {
                 it.baseName.endsWith(".9.png")
             })

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/RectBase.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/RectBase.kt
@@ -92,7 +92,7 @@ open class RectBase(
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
         val view = this
-        container.uiCollapsableSection("RectBase") {
+        container.uiCollapsibleSection("RectBase") {
             uiEditableValue(Pair(view::anchorX, view::anchorY), min = 0.0, max = 1.0, clamp = false, name = "anchor")
             button("Center") {
                 views.undoable("Change anchor", view) {

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Stage.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Stage.kt
@@ -53,7 +53,7 @@ class Stage(override val views: Views) : Container()
     }
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection("Stage") {
+        container.uiCollapsibleSection("Stage") {
             uiEditableValue(Pair(views::virtualWidthDouble, views::virtualHeightDouble), name = "virtualSize", min = 0.0, max = 2000.0).findObservableProperties().fastForEach {
                 it.onChange {
                     views.resized()

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Text.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Text.kt
@@ -286,7 +286,7 @@ open class Text(
     }
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection("Text") {
+        container.uiCollapsibleSection("Text") {
             uiEditableValue(::text)
             uiEditableValue(::textSize, min= 1.0, max = 300.0)
             uiEditableValue(::verticalAlign, values = { listOf(VerticalAlign.TOP, VerticalAlign.MIDDLE, VerticalAlign.BASELINE, VerticalAlign.BOTTOM) })

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/TreeViewRef.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/TreeViewRef.kt
@@ -21,7 +21,7 @@ class TreeViewRef() : Container(), ViewLeaf, ViewFileRef by ViewFileRef.Mixin() 
     }
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection("Tree") {
+        container.uiCollapsibleSection("Tree") {
             uiEditableValue(::sourceFile, kind = UiTextEditableValue.Kind.FILE(views.currentVfs) {
                 it.extensionLC == "ktree"
             })

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/VectorImage.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/VectorImage.kt
@@ -53,7 +53,7 @@ class VectorImage(
     }
 
     override fun buildDebugComponent(views: Views, container: UiContainer) {
-        container.uiCollapsableSection("VectorImage") {
+        container.uiCollapsibleSection("VectorImage") {
             uiEditableValue(this@VectorImage::sourceFile, kind = UiTextEditableValue.Kind.FILE(views.currentVfs) {
                 it.extensionLC == "svg"
             })

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/View.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/View.kt
@@ -91,13 +91,38 @@ abstract class View internal constructor(
     internal var _children: ArrayList<View>? = null
 
     /** Iterates all the children of this container in normal order of rendering. */
+    inline fun forEachChild(callback: (child: View) -> Unit) = _children?.fastForEach(callback)
+
+    /** Iterates all the children of this container in normal order of rendering. */
+    @Deprecated(
+        message = "An older name of `forEachChild`",
+        replaceWith = ReplaceWith("forEachChild(callback)"),
+        level = DeprecationLevel.WARNING
+    )
     inline fun forEachChildren(callback: (child: View) -> Unit) = _children?.fastForEach(callback)
 
     /** Iterates all the children of this container in normal order of rendering. Providing an index in addition to the child to the callback. */
+    inline fun forEachChildWithIndex(callback: (index: Int, child: View) -> Unit) =
+        _children?.fastForEachWithIndex(callback)
+
+    /** Iterates all the children of this container in normal order of rendering. Providing an index in addition to the child to the callback. */
+    @Deprecated(
+        message = "An older name of `forEachChildWithIndex`",
+        replaceWith = ReplaceWith("forEachChildWithIndex(callback)"),
+        level = DeprecationLevel.WARNING
+    )
     inline fun forEachChildrenWithIndex(callback: (index: Int, child: View) -> Unit) =
         _children?.fastForEachWithIndex(callback)
 
     /** Iterates all the children of this container in reverse order of rendering. */
+    inline fun forEachChildReversed(callback: (child: View) -> Unit) = _children?.fastForEachReverse(callback)
+
+    /** Iterates all the children of this container in reverse order of rendering. */
+    @Deprecated(
+        message = "An older name of `forEachChildReversed`",
+        replaceWith = ReplaceWith("forEachChildReversed(callback)"),
+        level = DeprecationLevel.WARNING
+    )
     inline fun forEachChildrenReversed(callback: (child: View) -> Unit) = _children?.fastForEachReverse(callback)
 
     /** Indicates if this view is going to propagate the events that reach this node to its children */
@@ -1173,7 +1198,7 @@ abstract class View internal constructor(
         if (this.name == name) return this
         if (this.isContainer) {
             //(this as Container).children.fastForEach { child ->
-            (this as Container).forEachChildren { child ->
+            (this as Container).forEachChild { child: View ->
                 val named = child.findViewByName(name)
                 if (named != null) return named
             }
@@ -1207,12 +1232,12 @@ abstract class View internal constructor(
         extraBuildDebugComponent?.invoke(views, view, container)
 
         if (filter != null) {
-            container.uiCollapsableSection("Filter") {
+            container.uiCollapsibleSection("Filter") {
                 filter!!.buildDebugComponent(views, this)
             }
         }
 
-        container.uiCollapsableSection("View") {
+        container.uiCollapsibleSection("View") {
             addChild(UiRowEditableValue(app, "type", UiLabel(app).also { it.text = view::class.simpleName ?: "Unknown" }))
             uiEditableValue(view::name)
             uiEditableValue(view::colorMul)
@@ -1483,7 +1508,7 @@ val View?.ancestors: List<View> get() = ancestorsUpTo(null)
 fun View?.dump(indent: String = "", emit: (String) -> Unit = ::println) {
     emit("$indent$this")
     if (this != null && this.isContainer) {
-        this.forEachChildren { child ->
+        this.forEachChild { child: View ->
             child.dump("$indent ", emit)
         }
     }
@@ -1507,7 +1532,7 @@ fun View?.foreachDescendant(handler: (View) -> Unit) {
     if (this != null) {
         handler(this)
         if (this.isContainer) {
-            this.forEachChildren { child ->
+            this.forEachChild { child: View ->
                 child.foreachDescendant(handler)
             }
         }
@@ -1576,7 +1601,7 @@ fun View?.firstDescendantWith(check: (View) -> Boolean): View? {
     if (this == null) return null
     if (check(this)) return this
     if (this.isContainer) {
-        this.forEachChildren { child ->
+        this.forEachChild { child: View ->
             val res = child.firstDescendantWith(check)
             if (res != null) return res
         }
@@ -1589,7 +1614,7 @@ fun View?.descendantsWith(out: ArrayList<View> = arrayListOf(), check: (View) ->
     if (this != null) {
         if (check(this)) out += this
         if (this.isContainer) {
-            this.forEachChildren { child ->
+            this.forEachChild { child: View ->
                 child.descendantsWith(out, check)
             }
         }

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Views.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Views.kt
@@ -503,11 +503,11 @@ private fun <T> ArrayList<T>.replaceOrAdd(pos: Int, value: T) {
 private fun getAllDescendantViewsBase(view: View, out: ArrayList<View>, reversed: Boolean, cursor: Int): Int {
     var pos = cursor
     if (reversed) {
-        view.forEachChildrenReversed { pos = getAllDescendantViewsBase(it, out, reversed, pos) }
+        view.forEachChildReversed { pos = getAllDescendantViewsBase(it, out, reversed, pos) }
         out.replaceOrAdd(pos++, view)
     } else {
         out.replaceOrAdd(pos++, view)
-        view.forEachChildren { pos = getAllDescendantViewsBase(it, out, reversed, pos) }
+        view.forEachChild { pos = getAllDescendantViewsBase(it, out, reversed, pos) }
     }
     return pos
 }

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/filter/FilterExt.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/filter/FilterExt.kt
@@ -19,7 +19,7 @@ fun ViewsContainer.registerFilterSerialization() {
             if (filter != null) {
                 val filters = filter.allFilters
                 for (filter in filters) {
-                    contentContainer.uiCollapsableSection(filter::class.simpleName) {
+                    contentContainer.uiCollapsibleSection(filter::class.simpleName) {
                         button("Remove Filter") {
                             view.removeFilter(filter)
                             updateContentContainer()

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/ktree/KTree.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/ktree/KTree.kt
@@ -352,7 +352,7 @@ open class KTreeSerializer(val views: Views) : KTreeSerializerHolder, Extra by E
             result ?: when (view) {
                 is NinePatchEx -> Xml("ninepatch", rproperties)
                 is KTreeRoot -> Xml("ktree", mapOf("width" to view.width, "height" to view.height, "gridWidth" to view.grid.width, "gridHeight" to view.grid.height)) {
-                    view.forEachChildren { this@Xml.node(viewTreeToKTree(it, currentVfs, level + 1)) }
+                    view.forEachChild { this@Xml.node(viewTreeToKTree(it, currentVfs, level + 1)) }
                 }
                 is AnimationViewRef -> Xml("animation", rproperties)
                 is ParticleEmitterView -> Xml("particle", rproperties)
@@ -365,7 +365,7 @@ open class KTreeSerializer(val views: Views) : KTreeSerializerHolder, Extra by E
                 is Text -> Xml("text", rproperties)
                 is UITextButton -> Xml("uitextbutton", rproperties)
                 is Container -> Xml("container", rproperties) {
-                    view.forEachChildren { this@Xml.node(viewTreeToKTree(it, currentVfs, level + 1)) }
+                    view.forEachChild { this@Xml.node(viewTreeToKTree(it, currentVfs, level + 1)) }
                 }
                 else -> error("Don't know how to serialize $view")
             }

--- a/korge/src/jvmMain/kotlin/com/soywiz/korge/awt/KTreeEditor.kt
+++ b/korge/src/jvmMain/kotlin/com/soywiz/korge/awt/KTreeEditor.kt
@@ -86,7 +86,7 @@ suspend fun ktreeEditor(fileToEdit: BaseKorgeFileToEdit): Module {
         //root.height = camera.height
 
         root.extraBuildDebugComponent = { views, view, container ->
-            container.uiCollapsableSection("Document") {
+            container.uiCollapsibleSection("Document") {
                 uiEditableValue(listOf(root::width, root::height), min = 0.0, max = 4096.0, clamp = true, name = "Document Size")
                 uiEditableValue(actions.grid::size, min = 1, max = 500, clamp = true, name = "Grid Size")
                 uiEditableValue(listOf(actions.grid::width, actions.grid::height), min = 1, max = 500, clamp = true, name = "Grid Size")


### PR DESCRIPTION
Some renames and deprecations (#315)

* Rename (with deprecations) uiCollapsableSection → uiCollapsibleSection; some other renames fixing eachChildren → eachChild