### PR TITLE
Rectangle corners

### DIFF
--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Rectangle.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Rectangle.kt
@@ -26,15 +26,15 @@ val IRectangle.top get() = _y
 val IRectangle.right get() = _x + _width
 val IRectangle.bottom get() = _y + _height
 
+val IRectangle.topLeft get() = Point(left, top)
+val IRectangle.topRight get() = Point(right, top)
+val IRectangle.bottomLeft get() = Point(left, bottom)
+val IRectangle.bottomRight get() = Point(right, bottom)
+
 data class Rectangle(
     var x: Double, var y: Double,
     var width: Double, var height: Double
 ) : MutableInterpolable<Rectangle>, Interpolable<Rectangle>, IRectangle, Sizeable {
-    val topLeft get() = Point(left, top)
-    val topRight get() = Point(right, top)
-    val bottomLeft get() = Point(left, bottom)
-    val bottomRight get() = Point(right, bottom)
-
     override val _x: Double get() = x
     override val _y: Double get() = y
     override val _width: Double get() = width

--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Rectangle.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Rectangle.kt
@@ -208,6 +208,11 @@ val IRectangleInt.top get() = y
 val IRectangleInt.right get() = x + width
 val IRectangleInt.bottom get() = y + height
 
+val IRectangleInt.topLeft get() = PointInt(left, top)
+val IRectangleInt.topRight get() = PointInt(right, top)
+val IRectangleInt.bottomLeft get() = PointInt(left, bottom)
+val IRectangleInt.bottomRight get() = PointInt(right, bottom)
+
 inline class RectangleInt(val rect: Rectangle) : IRectangleInt {
     override var x: Int
         set(value) = run { rect.x = value.toDouble() }

--- a/korma/src/commonTest/kotlin/com/soywiz/korma/geom/RectangleIntTest.kt
+++ b/korma/src/commonTest/kotlin/com/soywiz/korma/geom/RectangleIntTest.kt
@@ -9,4 +9,19 @@ class RectangleIntTest {
         assertEquals(SizeInt(25, 100), SizeInt(50, 200).fitTo(container = SizeInt(100, 100)))
         assertEquals(SizeInt(50, 200), SizeInt(50, 200).fitTo(container = SizeInt(100, 200)))
     }
+
+    @Test
+    fun corners() {
+        val rectangle = RectangleInt(1, 20, 300, 4000)
+        assertEquals(IPointInt(1, 20), rectangle.topLeft)
+        assertEquals(IPointInt(301, 20), rectangle.topRight)
+        assertEquals(IPointInt(1, 4020), rectangle.bottomLeft)
+        assertEquals(IPointInt(301, 4020), rectangle.bottomRight)
+
+        val iRectangle = IRectangleInt(1000, 200, 30, 4)
+        assertEquals(IPointInt(1000, 200), iRectangle.topLeft)
+        assertEquals(IPointInt(1030, 200), iRectangle.topRight)
+        assertEquals(IPointInt(1000, 204), iRectangle.bottomLeft)
+        assertEquals(IPointInt(1030, 204), iRectangle.bottomRight)
+    }
 }

--- a/korma/src/commonTest/kotlin/com/soywiz/korma/geom/RectangleTest.kt
+++ b/korma/src/commonTest/kotlin/com/soywiz/korma/geom/RectangleTest.kt
@@ -36,4 +36,19 @@ class RectangleTest {
         val out = Rectangle(0, 0, 100, 100).place(Size(50, 25), Anchor.MIDDLE_CENTER, ScaleMode.SHOW_ALL)
         assertEquals(Rectangle(0, 25, 100, 50), out)
     }
+
+    @Test
+    fun corners() {
+        val rectangle = Rectangle(1, 20, 300, 4000)
+        assertEquals(IPoint(1, 20), rectangle.topLeft)
+        assertEquals(IPoint(301, 20), rectangle.topRight)
+        assertEquals(IPoint(1, 4020), rectangle.bottomLeft)
+        assertEquals(IPoint(301, 4020), rectangle.bottomRight)
+
+        val iRectangle = IRectangle(1000, 200, 30, 4)
+        assertEquals(IPoint(1000, 200), iRectangle.topLeft)
+        assertEquals(IPoint(1030, 200), iRectangle.topRight)
+        assertEquals(IPoint(1000, 204), iRectangle.bottomLeft)
+        assertEquals(IPoint(1030, 204), iRectangle.bottomRight)
+    }
 }


### PR DESCRIPTION
Hi! I think one change from korlibs/korma#47 should be definitely presented in the repo: corner functions for RectangleInt, as Rectangle already has these functions.
The second change in this PR is moving corner functions from Rectangle to IRectangle, to make them available for immutable version of objects.