### PR TITLE
Makes Logger thread safe

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ buildscript {
         classpath("com.android.tools.build:gradle:4.0.1")
         //classpath("com.android.tools.build:gradle:4.1.0-rc03")
         //classpath("com.android.tools.build:gradle:4.2.0-alpha12")
+        classpath("org.jetbrains.kotlinx:atomicfu-gradle-plugin:0.15.1")
     }
 }
 

--- a/klogger/build.gradle
+++ b/klogger/build.gradle
@@ -1,7 +1,1 @@
-repositories {
-    mavenCentral()
-}
-
-dependencies {
-    commonMainApi("org.jetbrains.kotlinx:atomicfu:0.15.1")
-}
+apply plugin: 'kotlinx-atomicfu'

--- a/klogger/build.gradle
+++ b/klogger/build.gradle
@@ -1,0 +1,7 @@
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    commonMainApi("org.jetbrains.kotlinx:atomicfu:0.15.1")
+}

--- a/klogger/src/commonMain/kotlin/com/soywiz/klogger/Logger.kt
+++ b/klogger/src/commonMain/kotlin/com/soywiz/klogger/Logger.kt
@@ -1,11 +1,6 @@
 package com.soywiz.klogger
 
-private var Logger_loggers: LinkedHashMap<String, Logger> = LinkedHashMap()
-private var Logger_defaultLevel: Logger.Level? = null
-private var Logger_defaultOutput: Logger.Output = DefaultLogOutput
-
-private var Logger_levels: LinkedHashMap<String, Logger.Level?> = LinkedHashMap()
-private var Logger_outputs: LinkedHashMap<String, Logger.Output?> = LinkedHashMap()
+import kotlinx.atomicfu.*
 
 /**
  * Utility to log messages.
@@ -34,15 +29,15 @@ class Logger private constructor(val name: String, val dummy: Boolean) {
     val isLocalOutputSet: Boolean get() = Logger_outputs[name] != null
 
     companion object {
+        private val Logger_loggers: AtomicLinkedHashMap<String, Logger> = atomic(LinkedHashMap())
+        private val Logger_levels: AtomicLinkedHashMap<String, Level?> = atomic(LinkedHashMap())
+        private val Logger_outputs: AtomicLinkedHashMap<String, Output?> = atomic(LinkedHashMap())
+
         /** The default [Level] used for all [Logger] that doesn't have its [Logger.level] set */
-        var defaultLevel: Level?
-            get() = Logger_defaultLevel
-            set(value) = run { Logger_defaultLevel = value }
+        var defaultLevel: Level? by atomic(null)
 
         /** The default [Output] used for all [Logger] that doesn't have its [Logger.output] set */
-        var defaultOutput: Output
-            get() = Logger_defaultOutput
-            set(value) = run { Logger_defaultOutput = value }
+        var defaultOutput: Output by atomic(DefaultLogOutput)
 
         /** Gets a [Logger] from its [name] */
         operator fun invoke(name: String) = Logger_loggers[name] ?: Logger(name, true)
@@ -59,15 +54,15 @@ class Logger private constructor(val name: String, val dummy: Boolean) {
 
     /** Logging [Output] to handle logs */
     interface Output {
-        fun output(logger: Logger, level: Logger.Level, msg: Any?)
+        fun output(logger: Logger, level: Level, msg: Any?)
     }
 
     /** Default [Output] to emit logs over the [Console] */
-    object ConsoleLogOutput : Logger.Output {
-        override fun output(logger: Logger, level: Logger.Level, msg: Any?) {
+    object ConsoleLogOutput : Output {
+        override fun output(logger: Logger, level: Level, msg: Any?) {
             when (level) {
-                Logger.Level.ERROR -> Console.error(logger.name, msg)
-                Logger.Level.WARN -> Console.warn(logger.name, msg)
+                Level.ERROR -> Console.error(logger.name, msg)
+                Level.WARN -> Console.warn(logger.name, msg)
                 else -> Console.log(logger.name, msg)
             }
         }
@@ -124,3 +119,12 @@ fun Logger.setLevel(level: Logger.Level): Logger = this.apply { this.level = lev
 
 /** Sets the [Logger.output] */
 fun Logger.setOutput(output: Logger.Output): Logger = this.apply { this.output = output }
+
+private typealias AtomicLinkedHashMap<K, V> = AtomicRef<LinkedHashMap<K, V>>
+
+private operator fun <K, V> AtomicLinkedHashMap<K, V>.get(key: K) = value[key]
+private operator fun <K, V> AtomicLinkedHashMap<K, V>.set(key: K, value: V) = updateMap { this[key] = value }
+
+private inline fun <K, V> AtomicLinkedHashMap<K, V>.updateMap(updater: LinkedHashMap<K, V>.() -> Unit) =
+    this.update { LinkedHashMap(it).apply(updater) }
+

--- a/klogger/src/commonMain/kotlin/com/soywiz/klogger/Logger.kt
+++ b/klogger/src/commonMain/kotlin/com/soywiz/klogger/Logger.kt
@@ -122,8 +122,8 @@ fun Logger.setOutput(output: Logger.Output): Logger = this.apply { this.output =
 
 private typealias AtomicLinkedHashMap<K, V> = AtomicRef<LinkedHashMap<K, V>>
 
-private operator fun <K, V> AtomicLinkedHashMap<K, V>.get(key: K) = value[key]
-private operator fun <K, V> AtomicLinkedHashMap<K, V>.set(key: K, value: V) = updateMap { this[key] = value }
+private inline operator fun <K, V> AtomicLinkedHashMap<K, V>.get(key: K) = value[key]
+private inline operator fun <K, V> AtomicLinkedHashMap<K, V>.set(key: K, value: V) = updateMap { this[key] = value }
 
 private inline fun <K, V> AtomicLinkedHashMap<K, V>.updateMap(updater: LinkedHashMap<K, V>.() -> Unit) =
     this.update { LinkedHashMap(it).apply(updater) }

--- a/klogger/src/commonTest/kotlin/com/soywiz/klogger/test/LoggerTest.kt
+++ b/klogger/src/commonTest/kotlin/com/soywiz/klogger/test/LoggerTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class LoggerTest {
-	var out = atomic(listOf<String>())
+	val out = atomic(listOf<String>())
 
 	@Test
 	fun simple() {

--- a/klogger/src/commonTest/kotlin/com/soywiz/klogger/test/LoggerTest.kt
+++ b/klogger/src/commonTest/kotlin/com/soywiz/klogger/test/LoggerTest.kt
@@ -1,10 +1,14 @@
 package com.soywiz.klogger.test
 
-import com.soywiz.klogger.*
-import kotlin.test.*
+import com.soywiz.klogger.Logger
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.update
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class LoggerTest {
-	var out = listOf<String>()
+	var out = atomic(listOf<String>())
 
 	@Test
 	fun simple() {
@@ -13,19 +17,29 @@ class LoggerTest {
 		val logger = Logger("demo")
 		logger.output = object : Logger.Output {
 			override fun output(logger: Logger, level: Logger.Level, msg: Any?) {
-				out += "${logger.name}: $level: $msg"
+				out.update { it + "${logger.name}: $level: $msg" }
 			}
 		}
 		logger.level = Logger.Level.INFO
 		logger.warn { "mywarn" }
 		logger.info { "myinfo" }
 		logger.trace { "mytrace" }
-		assertEquals(listOf("demo: WARN: mywarn", "demo: INFO: myinfo"), out)
+		assertEquals(listOf("demo: WARN: mywarn", "demo: INFO: myinfo"), out.value)
 
 		logger.level = Logger.Level.WARN
 		logger.warn { "mywarn" }
 		logger.info { "myinfo" }
 		logger.trace { "mytrace" }
-		assertEquals(listOf("demo: WARN: mywarn", "demo: INFO: myinfo", "demo: WARN: mywarn"), out)
+		assertEquals(listOf("demo: WARN: mywarn", "demo: INFO: myinfo", "demo: WARN: mywarn"), out.value)
 	}
+
+    @Test
+    fun defaultLevel() {
+        Logger.defaultLevel = Logger.Level.ERROR
+        assertTrue { Logger.defaultLevel == Logger.Level.ERROR }
+
+        Logger.defaultLevel = Logger.Level.DEBUG
+        assertTrue { Logger.defaultLevel == Logger.Level.DEBUG }
+    }
+
 }

--- a/klogger/src/nativeCommonTest/kotlin/com.soywiz.klogger.test/LoggerMultithreadedTest.kt
+++ b/klogger/src/nativeCommonTest/kotlin/com.soywiz.klogger.test/LoggerMultithreadedTest.kt
@@ -1,0 +1,45 @@
+package com.soywiz.klogger.test
+
+import com.soywiz.klogger.Logger
+import kotlin.native.concurrent.*
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class LoggerMultithreadedTest {
+
+    @Test
+    fun multithreaded() {
+        val worker = Worker.start()
+        val logger = Logger("WorkerLogger")
+        val changeLoggerLevel: () -> Logger.Level = {
+            logger.level = Logger.Level.INFO
+            logger.level
+        }
+        val future = worker.execute(TransferMode.SAFE, { changeLoggerLevel.freeze() }) { it() }
+        val result = future.result
+
+        assertTrue(logger.isFrozen)
+        assertTrue { result == Logger.Level.INFO }
+        assertTrue { logger.level == Logger.Level.INFO }
+
+        val logger2 = Logger("WorkerLogger")
+        assertTrue { logger === logger2 }
+
+        val getLoggerLevel: () -> Logger.Level = {
+            logger2.level
+        }
+        val worker2 = Worker.start()
+        val future2 = worker2.execute(TransferMode.SAFE, { getLoggerLevel.freeze() }) { it() }
+        val result2 = future2.result
+
+        assertTrue(logger2.isFrozen)
+        assertTrue { result2 == Logger.Level.INFO }
+        assertTrue { logger2.level == Logger.Level.INFO }
+
+        assertTrue { logger.level == logger2.level }
+
+        logger.level = Logger.Level.DEBUG
+        assertTrue { logger.level == Logger.Level.DEBUG }
+        assertTrue { logger.level == logger2.level }
+    }
+}


### PR DESCRIPTION
The program would crash when accessing Logger from multiple threads in K/N due to the memory model.
As discussed on Slack https://kotlinlang.slack.com/archives/CJEF0LB6Y/p1609680019381100, the changes make Logger thread-safe by using atomic reference.