### PR TITLE
Minor performance optimization for JS

### DIFF
--- a/kmem/src/jsMain/kotlin/com/soywiz/kmem/BufferJs.kt
+++ b/kmem/src/jsMain/kotlin/com/soywiz/kmem/BufferJs.kt
@@ -20,48 +20,48 @@ actual typealias DataBuffer = DataView
 actual fun MemBuffer.getData(): DataBuffer = DataView(this)
 actual inline val DataBuffer.mem: MemBuffer get() = this.buffer
 actual fun DataBuffer.getByte(index: Int): Byte = this.getInt8(index)
-actual fun DataBuffer.setByte(index: Int, value: Byte): Unit = run { this.setInt8(index, value) }
+actual fun DataBuffer.setByte(index: Int, value: Byte): Unit = this.setInt8(index, value)
 actual fun DataBuffer.getShort(index: Int): Short = this.getInt16(index, true)
-actual fun DataBuffer.setShort(index: Int, value: Short): Unit = run { this.setInt16(index, value, true) }
+actual fun DataBuffer.setShort(index: Int, value: Short): Unit = this.setInt16(index, value, true)
 actual fun DataBuffer.getInt(index: Int): Int = this.getInt32(index, true)
-actual fun DataBuffer.setInt(index: Int, value: Int): Unit = run { this.setInt32(index, value, true) }
+actual fun DataBuffer.setInt(index: Int, value: Int): Unit = this.setInt32(index, value, true)
 actual fun DataBuffer.getFloat(index: Int): Float = this.getFloat32(index, true)
-actual fun DataBuffer.setFloat(index: Int, value: Float): Unit = run { this.setFloat32(index, value, true) }
+actual fun DataBuffer.setFloat(index: Int, value: Float): Unit = this.setFloat32(index, value, true)
 actual fun DataBuffer.getDouble(index: Int): Double = this.getFloat64(index, true)
-actual fun DataBuffer.setDouble(index: Int, value: Double): Unit = run { this.setFloat64(index, value, true) }
+actual fun DataBuffer.setDouble(index: Int, value: Double): Unit = this.setFloat64(index, value, true)
 
 actual typealias Int8Buffer = Int8Array
 actual inline val Int8Buffer.mem: MemBuffer get() = this.buffer
 actual inline val Int8Buffer.offset: Int get() = this.byteOffset / 1
-actual inline val Int8Buffer.size: Int get() = this.asDynamic().length
+actual inline val Int8Buffer.size: Int get() = this.length
 actual inline operator fun Int8Buffer.get(index: Int): Byte = this.asDynamic()[index]
 actual inline operator fun Int8Buffer.set(index: Int, value: Byte): Unit = run { this.asDynamic()[index] = value }
 
 actual typealias Int16Buffer = Int16Array
 actual inline val Int16Buffer.mem: MemBuffer get() = this.buffer
 actual inline val Int16Buffer.offset: Int get() = this.byteOffset / 2
-actual inline val Int16Buffer.size: Int get() = this.asDynamic().length
+actual inline val Int16Buffer.size: Int get() = this.length
 actual inline operator fun Int16Buffer.get(index: Int): Short = this.asDynamic()[index]
 actual inline operator fun Int16Buffer.set(index: Int, value: Short): Unit = run { this.asDynamic()[index] = value }
 
 actual typealias Int32Buffer = Int32Array
 actual inline val Int32Buffer.mem: MemBuffer get() = this.buffer
 actual inline val Int32Buffer.offset: Int get() = this.byteOffset / 4
-actual inline val Int32Buffer.size: Int get() = this.asDynamic().length
+actual inline val Int32Buffer.size: Int get() = this.length
 actual inline operator fun Int32Buffer.get(index: Int): Int = this.asDynamic()[index]
 actual inline operator fun Int32Buffer.set(index: Int, value: Int): Unit = run { this.asDynamic()[index] = value }
 
 actual typealias Float32Buffer = Float32Array
 actual inline val Float32Buffer.mem: MemBuffer get() = this.buffer
 actual inline val Float32Buffer.offset: Int get() = this.byteOffset / 4
-actual inline val Float32Buffer.size: Int get() = this.asDynamic().length
+actual inline val Float32Buffer.size: Int get() = this.length
 actual inline operator fun Float32Buffer.get(index: Int): Float = this.asDynamic()[index]
 actual inline operator fun Float32Buffer.set(index: Int, value: Float): Unit = run { this.asDynamic()[index] = value }
 
 actual typealias Float64Buffer = Float64Array
 actual inline val Float64Buffer.mem: MemBuffer get() = this.buffer
 actual inline val Float64Buffer.offset: Int get() = this.byteOffset / 8
-actual inline val Float64Buffer.size: Int get() = this.asDynamic().length
+actual inline val Float64Buffer.size: Int get() = this.length
 actual inline operator fun Float64Buffer.get(index: Int): Double = this.asDynamic()[index]
 actual inline operator fun Float64Buffer.set(index: Int, value: Double): Unit = run { this.asDynamic()[index] = value }
 
@@ -77,7 +77,7 @@ inline fun DoubleArray.asFloat64Array(): Float64Array = this.unsafeCast<Float64A
 inline fun DoubleArray.asTyped(): Float64Array = this.unsafeCast<Float64Array>()
 
 // @TODO (SAFARI BUG): Int8Array(dst, dstPos) -> Int8Array(dst, dstPos, size)
-actual fun arraycopy(src: MemBuffer, srcPos: Int, dst: MemBuffer, dstPos: Int, size: Int): Unit = Int8Array(dst, dstPos, size).set(Int8Array(src, srcPos, size), 0)
+actual fun arraycopy(src: MemBuffer, srcPos: Int, dst: MemBuffer, dstPos: Int, size: Int): Unit = Int8Array(dst , dstPos, size).set(Int8Array(src, srcPos, size), 0)
 actual fun arraycopy(src: ByteArray, srcPos: Int, dst: MemBuffer, dstPos: Int, size: Int): Unit = Int8Array(dst).set(src.asTyped().subarray(srcPos, srcPos + size), dstPos)
 actual fun arraycopy(src: MemBuffer, srcPos: Int, dst: ByteArray, dstPos: Int, size: Int): Unit = dst.asTyped().set(src._sliceInt8Buffer(0, src.size / 1).subarray(srcPos, srcPos + size), dstPos)
 actual fun arraycopy(src: ShortArray, srcPos: Int, dst: MemBuffer, dstPos: Int, size: Int): Unit = Int16Array(dst).set(src.asTyped().subarray(srcPos, srcPos + size), dstPos)

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/render/BatchBuilder2D.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/render/BatchBuilder2D.kt
@@ -320,7 +320,9 @@ class BatchBuilder2D constructor(
 	fun drawVertices(array: TexturedVertexArray, vcount: Int = array.vcount, icount: Int = array.isize) {
 		ensure(icount, vcount)
 
-		for (idx in 0 until min(icount, array.isize)) addIndex(vertexCount + array.indices[idx])
+        val minValue = if(icount < array.isize) icount else array.isize
+
+		for (idx in 0 until minValue) addIndex(vertexCount + array.indices[idx])
 		//for (p in array.points) addVertex(p.x, p.y, p.tx, p.ty, p.colMul, p.colAdd)
 
 		FBuffer.copy(array._data, 0, vertices, vertexPos * 4, vcount * 6 * 4)


### PR DESCRIPTION
Greetings, I found a surprising performance bottleneck in a for loop.

Going from:
```kotlin
for (idx in 0 until min(icount, array.isize)) addIndex(vertexCount + array.indices[idx])
``` 
to
```kotlin
val minValue = if(icount < array.isize) icount else array.isize

for (idx in 0 until minValue) addIndex(vertexCount + array.indices[idx])
```
made a surprising difference for me.


Before:
![image](https://user-images.githubusercontent.com/5893654/106474265-baebd880-6472-11eb-86e0-0ed5aa0c53d5.png)
After:
![image](https://user-images.githubusercontent.com/5893654/106474847-511ffe80-6473-11eb-8f5d-58db5d57b5e2.png)
