### PR TITLE
Make smoothing of TiledMapView customizable

### DIFF
--- a/korge/src/commonMain/kotlin/com/soywiz/korge/tiled/TiledMapView.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/tiled/TiledMapView.kt
@@ -7,15 +7,15 @@ import com.soywiz.korim.bitmap.*
 import com.soywiz.korim.color.*
 import com.soywiz.korma.geom.*
 
-inline fun Container.tiledMapView(tiledMap: TiledMap, showShapes: Boolean = true, callback: TiledMapView.() -> Unit = {}) =
-	TiledMapView(tiledMap, showShapes).addTo(this, callback)
+inline fun Container.tiledMapView(tiledMap: TiledMap, showShapes: Boolean = true, smoothing: Boolean = true, callback: TiledMapView.() -> Unit = {}) =
+	TiledMapView(tiledMap, showShapes, smoothing).addTo(this, callback)
 
-class TiledMapView(val tiledMap: TiledMap, showShapes: Boolean = true) : Container() {
+class TiledMapView(tiledMap: TiledMap, showShapes: Boolean = true, smoothing: Boolean = true) : Container() {
     val tileset = tiledMap.tilesets.toTileSet()
 	init {
 		tiledMap.allLayers.fastForEachWithIndex { index, layer ->
             val view: View = when (layer) {
-                is TiledMap.Layer.Tiles -> tileMap(layer.map, tileset)
+                is TiledMap.Layer.Tiles -> tileMap(layer.map, tileset, smoothing = smoothing)
                 //is TiledMap.Layer.Image -> image(layer.image)
                 is TiledMap.Layer.Objects -> {
                     container {

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/tiles/TileMap.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/tiles/TileMap.kt
@@ -13,23 +13,22 @@ import com.soywiz.korim.color.*
 import com.soywiz.korma.geom.*
 import kotlin.math.*
 
-inline fun Container.tileMap(map: IntArray2, tileset: TileSet, repeatX: TileMap.Repeat = TileMap.Repeat.NONE, repeatY: TileMap.Repeat = repeatX, callback: @ViewDslMarker TileMap.() -> Unit = {}) =
-	TileMap(map, tileset).repeat(repeatX, repeatY).addTo(this, callback)
+inline fun Container.tileMap(map: IntArray2, tileset: TileSet, repeatX: TileMap.Repeat = TileMap.Repeat.NONE, repeatY: TileMap.Repeat = repeatX, smoothing: Boolean = true, callback: @ViewDslMarker TileMap.() -> Unit = {}) =
+	TileMap(map, tileset, smoothing).repeat(repeatX, repeatY).addTo(this, callback)
 
-inline fun Container.tileMap(map: Bitmap32, tileset: TileSet, repeatX: TileMap.Repeat = TileMap.Repeat.NONE, repeatY: TileMap.Repeat = repeatX, callback: @ViewDslMarker TileMap.() -> Unit = {}) =
-	TileMap(map.toIntArray2(), tileset).repeat(repeatX, repeatY).addTo(this, callback)
+inline fun Container.tileMap(map: Bitmap32, tileset: TileSet, repeatX: TileMap.Repeat = TileMap.Repeat.NONE, repeatY: TileMap.Repeat = repeatX, smoothing: Boolean = true, callback: @ViewDslMarker TileMap.() -> Unit = {}) =
+	TileMap(map.toIntArray2(), tileset, smoothing).repeat(repeatX, repeatY).addTo(this, callback)
 
 @PublishedApi
 internal fun Bitmap32.toIntArray2() = IntArray2(width, height, data.ints)
 
 @OptIn(KorgeInternal::class)
-open class TileMap(val intMap: IntArray2, val tileset: TileSet) : View() {
+open class TileMap(val intMap: IntArray2, val tileset: TileSet, val smoothing: Boolean) : View() {
     private var contentVersion = 0
-	constructor(map: Bitmap32, tileset: TileSet) : this(map.toIntArray2(), tileset)
+	constructor(map: Bitmap32, tileset: TileSet, smoothing: Boolean) : this(map.toIntArray2(), tileset, smoothing)
 
 	val tileWidth = tileset.width.toDouble()
 	val tileHeight = tileset.height.toDouble()
-	var smoothing = true
 
 	enum class Repeat(val get: (v: Int, max: Int) -> Int) {
 		NONE({ v, max -> v }),

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/tiles/TileMap.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/tiles/TileMap.kt
@@ -23,7 +23,7 @@ inline fun Container.tileMap(map: Bitmap32, tileset: TileSet, repeatX: TileMap.R
 internal fun Bitmap32.toIntArray2() = IntArray2(width, height, data.ints)
 
 @OptIn(KorgeInternal::class)
-open class TileMap(val intMap: IntArray2, val tileset: TileSet, val smoothing: Boolean) : View() {
+open class TileMap(val intMap: IntArray2, val tileset: TileSet, var smoothing: Boolean = true) : View() {
     private var contentVersion = 0
 	constructor(map: Bitmap32, tileset: TileSet, smoothing: Boolean) : this(map.toIntArray2(), tileset, smoothing)
 

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/tiles/TileMap.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/tiles/TileMap.kt
@@ -25,7 +25,7 @@ internal fun Bitmap32.toIntArray2() = IntArray2(width, height, data.ints)
 @OptIn(KorgeInternal::class)
 open class TileMap(val intMap: IntArray2, val tileset: TileSet, var smoothing: Boolean = true) : View() {
     private var contentVersion = 0
-	constructor(map: Bitmap32, tileset: TileSet, smoothing: Boolean) : this(map.toIntArray2(), tileset, smoothing)
+	constructor(map: Bitmap32, tileset: TileSet, smoothing: Boolean = true) : this(map.toIntArray2(), tileset, smoothing)
 
 	val tileWidth = tileset.width.toDouble()
 	val tileHeight = tileset.height.toDouble()


### PR DESCRIPTION
I am currenlty porting my "retro" looking game with pixel-art graphics from
libGDX to Korge. The graphics are upscaled by factor 5 on the screen.
Now when looking into TileMapView I realized that the TileMapView is
always rendered with smoothing on. Thus my level map from Tiled looks
always blurred/smoothed.

This Pull request fixes this by making smoothing configurable. Here is
the git message text:

Rendering of a tiled map view is hardcoded to be done with smoothing
enabled. Smoothing property is not accessible because it is set in an
internal object which is not reachable from outside. This change
makes the smoothing parameter for the drawVertices call configurable
on creation of the TiledMapView object.

An unnecessary "val" string was cleaned up in the parameter list of
TiledMapView, too.