### PR TITLE
Bump JNA to 5.7.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ kotlinVersion=1.4.30
 coroutinesVersion=1.4.2
 androidBuildGradleVersion=4.0.1
 proguardVersion=6.2.2
-jnaVersion=5.6.0
+jnaVersion=5.7.0
 jcodecVersion=0.2.5
 
 playServicesAdsVersion=16.0.0
@@ -19,14 +19,12 @@ android.enableJetifier=true
 
 enableKotlinNative=true
 enableKotlinNativeLinux=true
-enableKotlinMobile=true
-enableKotlinAndroid=true
+enableKotlinMobile=trueenableKotlinAndroid=true
 
 #enableKotlinNative=false
 #enableKotlinNativeLinux=false
 #enableKotlinMobile=false
 #enableKotlinAndroid=false
-
 kotlin.native.disableCompilerDaemon=true
 
 kotlin.mpp.enableGranularSourceSetsMetadata=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,9 @@ android.enableJetifier=true
 
 enableKotlinNative=true
 enableKotlinNativeLinux=true
-enableKotlinMobile=trueenableKotlinAndroid=true
+enableKotlinMobile=true
+enableKotlinAndroid=true
+
 
 #enableKotlinNative=false
 #enableKotlinNativeLinux=false

--- a/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/BuildVersions.kt
+++ b/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/BuildVersions.kt
@@ -13,7 +13,7 @@ object BuildVersions {
 	const val KORGW = "2.0.0.999"
 	const val KORGE = "2.0.0.999"
 	const val KOTLIN = "1.4.30"
-    const val JNA = "5.6.0"
+    const val JNA = "5.7.0"
 	const val COROUTINES = "1.4.2"
 	const val ANDROID_BUILD = "4.0.1"
 }


### PR DESCRIPTION
Bump JNA Version to 5.7.0 for Apple Silicon Support
Fixes: https://github.com/korlibs/korge/issues/335
