### PR TITLE
Make rectangle contains function more generic

### DIFF
--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Rectangle.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Rectangle.kt
@@ -31,6 +31,12 @@ val IRectangle.topRight get() = Point(right, top)
 val IRectangle.bottomLeft get() = Point(left, bottom)
 val IRectangle.bottomRight get() = Point(right, bottom)
 
+operator fun IRectangle.contains(that: IPoint) = contains(that.x, that.y)
+operator fun IRectangle.contains(that: IPointInt) = contains(that.x, that.y)
+fun IRectangle.contains(x: Double, y: Double) = (x >= left && x < right) && (y >= top && y < bottom)
+fun IRectangle.contains(x: Float, y: Float) = contains(x.toDouble(), y.toDouble())
+fun IRectangle.contains(x: Int, y: Int) = contains(x.toDouble(), y.toDouble())
+
 data class Rectangle(
     var x: Double, var y: Double,
     var width: Double, var height: Double
@@ -90,11 +96,6 @@ data class Rectangle(
     operator fun div(scale: Int) = this / scale.toDouble()
 
     operator fun contains(that: Rectangle) = isContainedIn(that, this)
-    operator fun contains(that: Point) = contains(that.x, that.y)
-    operator fun contains(that: IPoint) = contains(that.x, that.y)
-    fun contains(x: Double, y: Double) = (x >= left && x < right) && (y >= top && y < bottom)
-    fun contains(x: Float, y: Float) = contains(x.toDouble(), y.toDouble())
-    fun contains(x: Int, y: Int) = contains(x.toDouble(), y.toDouble())
 
     infix fun intersects(that: Rectangle): Boolean = intersectsX(that) && intersectsY(that)
 
@@ -302,6 +303,11 @@ fun RectangleInt.setBoundsTo(left: Int, top: Int, right: Int, bottom: Int) = set
 ////////////////////
 
 operator fun IRectangleInt.contains(v: SizeInt): Boolean = (v.width <= width) && (v.height <= height)
+operator fun IRectangleInt.contains(that: IPoint) = contains(that.x, that.y)
+operator fun IRectangleInt.contains(that: IPointInt) = contains(that.x, that.y)
+fun IRectangleInt.contains(x: Double, y: Double) = (x >= left && x < right) && (y >= top && y < bottom)
+fun IRectangleInt.contains(x: Float, y: Float) = contains(x.toDouble(), y.toDouble())
+fun IRectangleInt.contains(x: Int, y: Int) = contains(x.toDouble(), y.toDouble())
 
 fun IRectangleInt.anchoredIn(container: RectangleInt, anchor: Anchor, out: RectangleInt = RectangleInt()): RectangleInt =
     out.setTo(

--- a/korma/src/commonTest/kotlin/com/soywiz/korma/geom/RectangleIntTest.kt
+++ b/korma/src/commonTest/kotlin/com/soywiz/korma/geom/RectangleIntTest.kt
@@ -2,6 +2,8 @@ package com.soywiz.korma.geom
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class RectangleIntTest {
     @Test
@@ -23,5 +25,65 @@ class RectangleIntTest {
         assertEquals(IPointInt(1030, 200), iRectangle.topRight)
         assertEquals(IPointInt(1000, 204), iRectangle.bottomLeft)
         assertEquals(IPointInt(1030, 204), iRectangle.bottomRight)
+    }
+    
+    @Test
+    fun containsPointInside() {
+        val rect = IRectangleInt(10, 20, 100, 200)
+        val point = IPointInt(11, 21)
+
+        assertTrue(point.float in rect)
+        assertTrue(point in rect)
+        assertTrue(rect.contains(point.x.toDouble(), point.y.toDouble()))
+        assertTrue(rect.contains(point.x.toFloat(), point.y.toFloat()))
+        assertTrue(rect.contains(point.x, point.y))
+    }
+
+    @Test
+    fun doesNotContainPointToTheLeft() {
+        val rect = IRectangleInt(10, 20, 100, 200)
+        val point = IPointInt(9, 21)
+
+        assertFalse(point.float in rect)
+        assertFalse(point in rect)
+        assertFalse(rect.contains(point.x.toDouble(), point.y.toDouble()))
+        assertFalse(rect.contains(point.x.toFloat(), point.y.toFloat()))
+        assertFalse(rect.contains(point.x, point.y))
+    }
+
+    @Test
+    fun doesNotContainPointToTheTop() {
+        val rect = IRectangleInt(10, 20, 100, 200)
+        val point = IPointInt(11, 19)
+
+        assertFalse(point.float in rect)
+        assertFalse(point in rect)
+        assertFalse(rect.contains(point.x.toDouble(), point.y.toDouble()))
+        assertFalse(rect.contains(point.x.toFloat(), point.y.toFloat()))
+        assertFalse(rect.contains(point.x, point.y))
+    }
+
+    @Test
+    fun doesNotContainPointToTheRight() {
+        val rect = IRectangleInt(10, 20, 100, 200)
+        val point = IPointInt(110, 21)
+
+        assertFalse(point.float in rect)
+        assertFalse(point in rect)
+        assertFalse(rect.contains(point.x.toDouble(), point.y.toDouble()))
+        assertFalse(rect.contains(point.x.toFloat(), point.y.toFloat()))
+        assertFalse(rect.contains(point.x, point.y))
+    }
+
+    @Test
+    fun doesNotContainPointToTheBottom() {
+        val rect = IRectangleInt(10, 20, 100, 200)
+        val point = IPointInt(11, 220)
+
+        assertFalse(point.float in rect)
+        assertFalse(point in rect)
+        assertFalse(rect.contains(point.x.toDouble(), point.y.toDouble()))
+        assertFalse(rect.contains(point.x.toFloat(), point.y.toFloat()))
+        assertFalse(rect.contains(point.x, point.y))
     }
 }

--- a/korma/src/commonTest/kotlin/com/soywiz/korma/geom/RectangleTest.kt
+++ b/korma/src/commonTest/kotlin/com/soywiz/korma/geom/RectangleTest.kt
@@ -51,4 +51,64 @@ class RectangleTest {
         assertEquals(IPoint(1000, 204), iRectangle.bottomLeft)
         assertEquals(IPoint(1030, 204), iRectangle.bottomRight)
     }
+
+    @Test
+    fun containsPointInside() {
+        val rect = IRectangle(10, 20, 100, 200)
+        val point = IPointInt(11, 21)
+
+        assertTrue(point.float in rect)
+        assertTrue(point in rect)
+        assertTrue(rect.contains(point.x.toDouble(), point.y.toDouble()))
+        assertTrue(rect.contains(point.x.toFloat(), point.y.toFloat()))
+        assertTrue(rect.contains(point.x, point.y))
+    }
+
+    @Test
+    fun doesNotContainPointToTheLeft() {
+        val rect = IRectangle(10, 20, 100, 200)
+        val point = IPointInt(9, 21)
+
+        assertFalse(point.float in rect)
+        assertFalse(point in rect)
+        assertFalse(rect.contains(point.x.toDouble(), point.y.toDouble()))
+        assertFalse(rect.contains(point.x.toFloat(), point.y.toFloat()))
+        assertFalse(rect.contains(point.x, point.y))
+    }
+
+    @Test
+    fun doesNotContainPointToTheTop() {
+        val rect = IRectangle(10, 20, 100, 200)
+        val point = IPointInt(11, 19)
+
+        assertFalse(point.float in rect)
+        assertFalse(point in rect)
+        assertFalse(rect.contains(point.x.toDouble(), point.y.toDouble()))
+        assertFalse(rect.contains(point.x.toFloat(), point.y.toFloat()))
+        assertFalse(rect.contains(point.x, point.y))
+    }
+
+    @Test
+    fun doesNotContainPointToTheRight() {
+        val rect = IRectangle(10, 20, 100, 200)
+        val point = IPointInt(110, 21)
+
+        assertFalse(point.float in rect)
+        assertFalse(point in rect)
+        assertFalse(rect.contains(point.x.toDouble(), point.y.toDouble()))
+        assertFalse(rect.contains(point.x.toFloat(), point.y.toFloat()))
+        assertFalse(rect.contains(point.x, point.y))
+    }
+
+    @Test
+    fun doesNotContainPointToTheBottom() {
+        val rect = IRectangle(10, 20, 100, 200)
+        val point = IPointInt(11, 220)
+
+        assertFalse(point.float in rect)
+        assertFalse(point in rect)
+        assertFalse(rect.contains(point.x.toDouble(), point.y.toDouble()))
+        assertFalse(rect.contains(point.x.toFloat(), point.y.toFloat()))
+        assertFalse(rect.contains(point.x, point.y))
+    }
 }


### PR DESCRIPTION
This PR:
1. Allows usage of `.contains` for `IRectangle` (before it worked only for `Rectangle`).
1. Removes `.contains(that: Point)` because there is `contains(that: IPoint)` already.
1. Adds `.contains(that: PointInt)`.
1. Adds the same functions for `IRectangleInt`.
1. Adds tests for these methods.