### PR TITLE
Add missing constructors for int metrics

### DIFF
--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Point.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Point.kt
@@ -282,6 +282,7 @@ inline class PointInt(val p: Point) : IPointInt, Comparable<IPointInt> {
     companion object {
         operator fun invoke(): PointInt = PointInt(0, 0)
         operator fun invoke(x: Int, y: Int): PointInt = PointInt(Point(x, y))
+        operator fun invoke(that: IPointInt): PointInt = PointInt(Point(that.x, that.y))
 
         fun compare(lx: Int, ly: Int, rx: Int, ry: Int): Int {
             val ret = ly.compareTo(ry)

--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Rectangle.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Rectangle.kt
@@ -258,6 +258,7 @@ inline class RectangleInt(val rect: Rectangle) : IRectangleInt {
         operator fun invoke(x: Int, y: Int, width: Int, height: Int) = RectangleInt(Rectangle(x, y, width, height))
         operator fun invoke(x: Float, y: Float, width: Float, height: Float) = RectangleInt(Rectangle(x, y, width, height))
         operator fun invoke(x: Double, y: Double, width: Double, height: Double) = RectangleInt(Rectangle(x, y, width, height))
+        operator fun invoke(other: IRectangleInt) = RectangleInt(Rectangle(other.x, other.y, other.width, other.height))
 
         fun fromBounds(left: Int, top: Int, right: Int, bottom: Int): RectangleInt =
             RectangleInt(left, top, right - left, bottom - top)

--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Size.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Size.kt
@@ -66,12 +66,17 @@ inline class Size(val p: Point) : MutableInterpolable<Size>, Interpolable<Size>,
 interface ISizeInt {
     val width: Int
     val height: Int
+
+    companion object {
+        operator fun invoke(width: Int, height: Int): ISizeInt = SizeInt(width, height)
+    }
 }
 
 inline class SizeInt(val size: Size) : ISizeInt {
     companion object {
         operator fun invoke(): SizeInt = SizeInt(Size(0, 0))
         operator fun invoke(x: Int, y: Int): SizeInt = SizeInt(Size(x, y))
+        operator fun invoke(that: ISizeInt): SizeInt = SizeInt(Size(that.width, that.height))
     }
 
     fun clone() = SizeInt(size.clone())


### PR DESCRIPTION
This PR adds methods for constructing metrics that I miss in my project:
1. I haven't found a way of copying immutable metrics to a mutable object, so I add three methods to SizeInt, PointInt, and RectangleInt.
1. There was no way of constructing ISizeInt, so I added it.