### PR TITLE
Fast sprite improvements - support for rotation and color

### DIFF
--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSprite.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSprite.kt
@@ -27,6 +27,11 @@ open class FastSprite(tex: BmpSlice) {
     // sin(rotation) value
     var sr: Float = 0f
 
+    internal var useRotation = false
+
+    /**
+     * Updates based on rotation
+     */
     private fun updateXY0123() {
         val px = xf - ax
         val py = yf - ay
@@ -50,17 +55,50 @@ open class FastSprite(tex: BmpSlice) {
         y3 = py1 * cr + px * sr + yf
     }
 
+    /**
+     * Updates x without rotation
+     */
+    private fun updateX01() {
+        x0 = xf - ax
+        x1 = x0 + w
+    }
+
+    private fun updateX() {
+        if (useRotation) {
+            updateXY0123()
+        } else {
+            updateX01()
+        }
+    }
+
+    /**
+     * Updates y without rotation
+     */
+    private fun updateY01() {
+        y0 = yf - ay
+        y1 = y0 + h
+    }
+
+    private fun updateY() {
+        if (useRotation) {
+            updateXY0123()
+        } else {
+            updateY01()
+        }
+    }
+
     private fun updateXSize() {
         w = width * scaleXf
         ax = w * anchorXf
-        updateXY0123()
+        updateX()
     }
 
     private fun updateYSize() {
         h = height * scaleYf
         ay = h * anchorYf
-        updateXY0123()
+        updateY()
     }
+
 
     private fun updateSize() {
         updateXSize()
@@ -70,12 +108,12 @@ open class FastSprite(tex: BmpSlice) {
     var xf: Float = 0f
         set(value) {
             field = value
-            updateXY0123()
+            updateX()
         }
     var yf: Float = 0f
         set(value) {
             field = value
-            updateXY0123()
+            updateY()
         }
     var anchorXf: Float = .5f
         set(value) {
@@ -91,7 +129,6 @@ open class FastSprite(tex: BmpSlice) {
                 updateYSize()
             }
         }
-
     var scaleXf: Float = 1f
         set(value) {
             if (field != value) {
@@ -106,14 +143,15 @@ open class FastSprite(tex: BmpSlice) {
                 updateYSize()
             }
         }
-
     var rotationRadiansf: Float = 0f
         set(value) {
             if (field != value) {
                 field = value
-                cr = cos(field)
-                sr = sin(field)
-                updateXY0123()
+                if(useRotation) {
+                    cr = cos(field)
+                    sr = sin(field)
+                    updateXY0123()
+                }
             }
         }
 
@@ -194,5 +232,5 @@ var FastSprite.rotation: Double
 var FastSprite.alpha
     get() = color.af
     set(value) {
-       color = color.withAf(value)
+        color = color.withAf(value)
     }

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSprite.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSprite.kt
@@ -15,9 +15,6 @@ open class FastSprite(tex: BmpSlice) {
     var x3: Float = 0f
     var y3: Float = 0f
 
-    var w: Float = 0f
-    var h: Float = 0f
-
     var ax: Float = 0f
     var ay: Float = 0f
 
@@ -48,27 +45,27 @@ open class FastSprite(tex: BmpSlice) {
      */
     private fun updateXY0123() {
         // top left
-        var px = anchorXf * scaleXf
-        var py = anchorYf * scaleYf
+        var px = -ax * scaleXf
+        var py = -ay * scaleYf
         x0 = px * cr - py * sr + xf
         y0 = py * cr + px * sr + yf
 
         // top right
-        px = (anchorXf + width) * scaleXf
-        py = anchorYf * scaleYf
+        px = (-ax + width) * scaleXf
+        py = -ay * scaleYf
         x1 = px * cr - py * sr + xf
         y1 = py * cr + px * sr + yf
 
 
         // bottom right
-        px = (anchorXf + width) * scaleXf
-        py = (anchorYf + height) * scaleYf
+        px = (-ax + width) * scaleXf
+        py = (-ay + height) * scaleYf
         x2 = px * cr - py * sr + xf
         y2 = py * cr + px * sr + yf
 
         // bottom left
-        px = anchorXf * scaleXf
-        py = (anchorYf + height) * scaleYf
+        px = -ax * scaleXf
+        py = (-ay + height) * scaleYf
         x3 = px * cr - py * sr + xf
         y3 = py * cr + px * sr + yf
     }
@@ -77,8 +74,8 @@ open class FastSprite(tex: BmpSlice) {
      * Updates x without rotation
      */
     private fun updateX01() {
-        x0 = xf - ax
-        x1 = x0 + w
+        x0 = xf - ax * scaleXf
+        x1 = x0 + width * scaleXf
     }
 
     private fun updateX() {
@@ -93,8 +90,8 @@ open class FastSprite(tex: BmpSlice) {
      * Updates y without rotation
      */
     private fun updateY01() {
-        y0 = yf - ay
-        y1 = y0 + h
+        y0 = yf - ay * scaleYf
+        y1 = y0 + height * scaleYf
     }
 
     private fun updateY() {
@@ -106,14 +103,12 @@ open class FastSprite(tex: BmpSlice) {
     }
 
     private fun updateXSize() {
-        w = width * scaleXf
-        ax = w * anchorXf
+        ax = width * anchorXf
         updateX()
     }
 
     private fun updateYSize() {
-        h = height * scaleYf
-        ay = h * anchorYf
+        ay = height * anchorYf
         updateY()
     }
 
@@ -202,7 +197,7 @@ open class FastSprite(tex: BmpSlice) {
     }
 
     override fun toString(): String {
-        return "FastSprite(x0=$x0, y0=$y0, x1=$x1, y1=$y1, x2=$x2, y2=$y2, x3=$x3, y3=$y3, w=$w, h=$h, ax=$ax, ay=$ay, cr=$cr, sr=$sr, container=$container, useRotation=$useRotation, xf=$xf, yf=$yf, anchorXf=$anchorXf, anchorYf=$anchorYf, scaleXf=$scaleXf, scaleYf=$scaleYf, rotationRadiansf=$rotationRadiansf, color=$color, visible=$visible, tex=$tex)"
+        return "FastSprite(x0=$x0, y0=$y0, x1=$x1, y1=$y1, x2=$x2, y2=$y2, x3=$x3, y3=$y3, ax=$ax, ay=$ay, cr=$cr, sr=$sr, container=$container, useRotation=$useRotation, xf=$xf, yf=$yf, anchorXf=$anchorXf, anchorYf=$anchorYf, scaleXf=$scaleXf, scaleYf=$scaleYf, rotationRadiansf=$rotationRadiansf, color=$color, visible=$visible, tex=$tex)"
     }
 
 }

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSprite.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSprite.kt
@@ -27,6 +27,9 @@ open class FastSprite(tex: BmpSlice) {
     // sin(rotation) value
     var sr: Float = 0f
 
+    var container: FastSpriteContainer? = null
+        internal set
+
     internal var useRotation = false
 
     /**
@@ -147,7 +150,7 @@ open class FastSprite(tex: BmpSlice) {
         set(value) {
             if (field != value) {
                 field = value
-                if(useRotation) {
+                if (useRotation) {
                     cr = cos(field)
                     sr = sin(field)
                     updateXY0123()

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSprite.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSprite.kt
@@ -1,12 +1,19 @@
 package com.soywiz.korge.view.fast
 
-import com.soywiz.korim.bitmap.*
+import com.soywiz.korim.bitmap.BmpSlice
+import com.soywiz.korim.color.Colors
+import kotlin.math.cos
+import kotlin.math.sin
 
 open class FastSprite(tex: BmpSlice) {
     var x0: Float = 0f
     var y0: Float = 0f
     var x1: Float = 0f
     var y1: Float = 0f
+    var x2: Float = 0f
+    var y2: Float = 0f
+    var x3: Float = 0f
+    var y3: Float = 0f
 
     var w: Float = 0f
     var h: Float = 0f
@@ -14,31 +21,45 @@ open class FastSprite(tex: BmpSlice) {
     var ax: Float = 0f
     var ay: Float = 0f
 
-    private fun updateX01() {
-        x0 = xf - ax
-        x1 = x0 + w
-    }
+    // cos(rotation) value
+    var cr: Float = 1f
 
-    private fun updateY01() {
-        y0 = yf - ay
-        y1 = y0 + h
-    }
+    // sin(rotation) value
+    var sr: Float = 0f
 
-    private fun updateXY01() {
-        updateX01()
-        updateY01()
+    private fun updateXY0123() {
+        val px = xf - ax
+        val py = yf - ay
+        val px1 = px + w
+        val py1 = py + h
+
+        // top left
+        x0 = px * cr - py * sr + xf
+        y0 = py * cr + px * sr + yf
+
+        // top right
+        x1 = px1 * cr - py * sr + xf
+        y1 = py * cr + px1 * sr + yf
+
+        // bottom right
+        x2 = px1 * cr - py1 * sr + xf
+        y2 = py1 * cr + px1 * sr + yf
+
+        // bottom left
+        x3 = px * cr - py1 * sr + xf
+        y3 = py1 * cr + px * sr + yf
     }
 
     private fun updateXSize() {
-        w = width * scalef
+        w = width * scaleXf
         ax = w * anchorXf
-        updateX01()
+        updateXY0123()
     }
 
     private fun updateYSize() {
-        h = height * scalef
+        h = height * scaleYf
         ay = h * anchorYf
-        updateY01()
+        updateXY0123()
     }
 
     private fun updateSize() {
@@ -49,12 +70,12 @@ open class FastSprite(tex: BmpSlice) {
     var xf: Float = 0f
         set(value) {
             field = value
-            updateX01()
+            updateXY0123()
         }
     var yf: Float = 0f
         set(value) {
             field = value
-            updateY01()
+            updateXY0123()
         }
     var anchorXf: Float = .5f
         set(value) {
@@ -70,13 +91,34 @@ open class FastSprite(tex: BmpSlice) {
                 updateYSize()
             }
         }
-    var scalef: Float = 1f
+
+    var scaleXf: Float = 1f
         set(value) {
             if (field != value) {
                 field = value
-                updateSize()
+                updateXSize()
             }
         }
+    var scaleYf: Float = 1f
+        set(value) {
+            if (field != value) {
+                field = value
+                updateYSize()
+            }
+        }
+
+    var rotationRadiansf: Float = 0f
+        set(value) {
+            if (field != value) {
+                field = value
+                cr = cos(field)
+                sr = sin(field)
+                updateXY0123()
+            }
+        }
+
+    var color = Colors.WHITE
+    var visible: Boolean = true
 
     val tx0: Float get() = tex.tl_x
     val ty0: Float get() = tex.tl_y
@@ -93,28 +135,64 @@ open class FastSprite(tex: BmpSlice) {
             }
         }
 
+    fun scale(value: Float) {
+        scaleXf = value
+        scaleYf = value
+    }
+
     init {
         updateSize()
-        updateXY01()
+        updateXY0123()
     }
 }
 
 var FastSprite.x: Double
     get() = xf.toDouble()
-    set(value) { xf = value.toFloat() }
+    set(value) {
+        xf = value.toFloat()
+    }
 
 var FastSprite.y: Double
     get() = yf.toDouble()
-    set(value) { yf = value.toFloat() }
+    set(value) {
+        yf = value.toFloat()
+    }
 
 var FastSprite.anchorX: Double
     get() = anchorXf.toDouble()
-    set(value) { anchorXf = value.toFloat() }
+    set(value) {
+        anchorXf = value.toFloat()
+    }
 
 var FastSprite.anchorY: Double
     get() = anchorYf.toDouble()
-    set(value) { anchorYf = value.toFloat() }
+    set(value) {
+        anchorYf = value.toFloat()
+    }
 
-var FastSprite.scale: Double
-    get() = scalef.toDouble()
-    set(value) { scalef = value.toFloat() }
+var FastSprite.scaleX: Double
+    get() = scaleXf.toDouble()
+    set(value) {
+        scaleXf = value.toFloat()
+    }
+var FastSprite.scaleY: Double
+    get() = scaleYf.toDouble()
+    set(value) {
+        scaleYf = value.toFloat()
+    }
+
+fun FastSprite.scale(value: Double) {
+    scale(value.toFloat())
+}
+
+var FastSprite.rotation: Double
+    get() = rotationRadiansf.toDouble()
+    set(value) {
+        rotationRadiansf = value.toFloat()
+    }
+
+var FastSprite.alpha
+    get() = color.af
+    set(value) {
+       color = color.withAf(value)
+    }

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSprite.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSprite.kt
@@ -36,6 +36,10 @@ open class FastSprite(tex: BmpSlice) {
      * Allows FastSpriteContainer to recalculate a FastSprite if added to a FastSpriteContainer using rotation
      */
     internal fun forceUpdate() {
+        if (useRotation) {
+            cr = cos(rotationRadiansf)
+            sr = sin(rotationRadiansf)
+        }
         updateSize()
     }
 
@@ -43,26 +47,30 @@ open class FastSprite(tex: BmpSlice) {
      * Updates based on rotation
      */
     private fun updateXY0123() {
-        val px = xf - ax
-        val py = yf - ay
-        val px1 = px + w
-        val py1 = py + h
-
         // top left
-        x0 = px * cr - py * sr
-        y0 = py * cr + px * sr
+        var px = anchorXf * scaleXf
+        var py = anchorYf * scaleYf
+        x0 = px * cr - py * sr + xf
+        y0 = py * cr + px * sr + yf
 
         // top right
-        x1 = px1 * cr - py * sr
-        y1 = py * cr + px1 * sr
+        px = (anchorXf + width) * scaleXf
+        py = anchorYf * scaleYf
+        x1 = px * cr - py * sr + xf
+        y1 = py * cr + px * sr + yf
+
 
         // bottom right
-        x2 = px1 * cr - py1 * sr
-        y2 = py1 * cr + px1 * sr
+        px = (anchorXf + width) * scaleXf
+        py = (anchorYf + height) * scaleYf
+        x2 = px * cr - py * sr + xf
+        y2 = py * cr + px * sr + yf
 
         // bottom left
-        x3 = px * cr - py1 * sr
-        y3 = py1 * cr + px * sr
+        px = anchorXf * scaleXf
+        py = (anchorYf + height) * scaleYf
+        x3 = px * cr - py * sr + xf
+        y3 = py * cr + px * sr + yf
     }
 
     /**
@@ -192,6 +200,11 @@ open class FastSprite(tex: BmpSlice) {
         updateSize()
         updateXY0123()
     }
+
+    override fun toString(): String {
+        return "FastSprite(x0=$x0, y0=$y0, x1=$x1, y1=$y1, x2=$x2, y2=$y2, x3=$x3, y3=$y3, w=$w, h=$h, ax=$ax, ay=$ay, cr=$cr, sr=$sr, container=$container, useRotation=$useRotation, xf=$xf, yf=$yf, anchorXf=$anchorXf, anchorYf=$anchorYf, scaleXf=$scaleXf, scaleYf=$scaleYf, rotationRadiansf=$rotationRadiansf, color=$color, visible=$visible, tex=$tex)"
+    }
+
 }
 
 var FastSprite.x: Double

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSprite.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSprite.kt
@@ -33,6 +33,13 @@ open class FastSprite(tex: BmpSlice) {
     internal var useRotation = false
 
     /**
+     * Allows FastSpriteContainer to recalculate a FastSprite if added to a FastSpriteContainer using rotation
+     */
+    internal fun forceUpdate() {
+        updateSize()
+    }
+
+    /**
      * Updates based on rotation
      */
     private fun updateXY0123() {
@@ -42,20 +49,20 @@ open class FastSprite(tex: BmpSlice) {
         val py1 = py + h
 
         // top left
-        x0 = px * cr - py * sr + xf
-        y0 = py * cr + px * sr + yf
+        x0 = px * cr - py * sr
+        y0 = py * cr + px * sr
 
         // top right
-        x1 = px1 * cr - py * sr + xf
-        y1 = py * cr + px1 * sr + yf
+        x1 = px1 * cr - py * sr
+        y1 = py * cr + px1 * sr
 
         // bottom right
-        x2 = px1 * cr - py1 * sr + xf
-        y2 = py1 * cr + px1 * sr + yf
+        x2 = px1 * cr - py1 * sr
+        y2 = py1 * cr + px1 * sr
 
         // bottom left
-        x3 = px * cr - py1 * sr + xf
-        y3 = py1 * cr + px * sr + yf
+        x3 = px * cr - py1 * sr
+        y3 = py1 * cr + px * sr
     }
 
     /**

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSpriteContainer.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSpriteContainer.kt
@@ -11,10 +11,11 @@ import com.soywiz.korge.view.addTo
 
 inline fun Container.fastSpriteContainer(
     useRotation: Boolean = false,
+    smoothing: Boolean = true,
     callback: @ViewDslMarker FastSpriteContainer.() -> Unit = {}
 ): FastSpriteContainer = FastSpriteContainer(useRotation).addTo(this, callback)
 
-class FastSpriteContainer(val useRotation: Boolean = false) : View() {
+class FastSpriteContainer(val useRotation: Boolean = false, var smoothing:Boolean = true) : View() {
     private val sprites = FastArrayList<FastSprite>()
 
     val numChildren get() = sprites.size
@@ -55,7 +56,7 @@ class FastSpriteContainer(val useRotation: Boolean = false) : View() {
         bb.setViewMatrixTemp(globalMatrix) {
             ////////////////////////////
 
-            bb.setStateFast(bmp, true, blendMode.factors, null)
+            bb.setStateFast(bmp, smoothing, blendMode.factors, null)
 
             ////////////////////////////
 

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSpriteContainer.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSpriteContainer.kt
@@ -10,15 +10,17 @@ import com.soywiz.korge.view.ViewDslMarker
 import com.soywiz.korge.view.addTo
 
 inline fun Container.fastSpriteContainer(
+    useRotation: Boolean = false,
     callback: @ViewDslMarker FastSpriteContainer.() -> Unit = {}
-): FastSpriteContainer = FastSpriteContainer().addTo(this, callback)
+): FastSpriteContainer = FastSpriteContainer(useRotation).addTo(this, callback)
 
-class FastSpriteContainer() : View() {
+class FastSpriteContainer(val useRotation: Boolean = false) : View() {
     private val sprites = FastArrayList<FastSprite>()
 
     val numChildren get() = sprites.size
 
     fun addChild(sprite: FastSprite) {
+        sprite.useRotation = useRotation
         this.sprites.add(sprite)
     }
 
@@ -91,13 +93,22 @@ class FastSpriteContainer() : View() {
         for (n in m until mMax) {
             //spriteCount++
             val sprite = sprites[n]
-            vp = bb._addQuadVerticesFastNormal(
-                vp, vd,
-                sprite.x0, sprite.y0, sprite.x1, sprite.y1,
-                sprite.x2, sprite.y2, sprite.x3, sprite.y3,
-                sprite.tx0, sprite.ty0, sprite.tx1, sprite.ty1,
-                sprite.color.value, colorAdd
-            )
+            if (useRotation) {
+                vp = bb._addQuadVerticesFastNormal(
+                    vp, vd,
+                    sprite.x0, sprite.y0, sprite.x1, sprite.y1,
+                    sprite.x2, sprite.y2, sprite.x3, sprite.y3,
+                    sprite.tx0, sprite.ty0, sprite.tx1, sprite.ty1,
+                    sprite.color.value, colorAdd
+                )
+            } else {
+                vp = bb._addQuadVerticesFastNormalNonRotated(
+                    vp, vd,
+                    sprite.x0, sprite.y0, sprite.x1, sprite.y1,
+                    sprite.tx0, sprite.ty0, sprite.tx1, sprite.ty1,
+                    sprite.color.value, colorAdd
+                )
+            }
         }
         bb.vertexPos = vp
         bb.vertexCount = count * 4

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSpriteContainer.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSpriteContainer.kt
@@ -13,7 +13,7 @@ inline fun Container.fastSpriteContainer(
     useRotation: Boolean = false,
     smoothing: Boolean = true,
     callback: @ViewDslMarker FastSpriteContainer.() -> Unit = {}
-): FastSpriteContainer = FastSpriteContainer(useRotation).addTo(this, callback)
+): FastSpriteContainer = FastSpriteContainer(useRotation, smoothing).addTo(this, callback)
 
 class FastSpriteContainer(val useRotation: Boolean = false, var smoothing:Boolean = true) : View() {
     private val sprites = FastArrayList<FastSprite>()

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSpriteContainer.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSpriteContainer.kt
@@ -91,10 +91,15 @@ class FastSpriteContainer(val useRotation: Boolean = false) : View() {
         var vp = bb.vertexPos
         val vd = bb.verticesFast32
         val mMax = min2(sprites.size, m + batchSize)
-        val count = mMax - m
+        var count = mMax - m
         for (n in m until mMax) {
             //spriteCount++
             val sprite = sprites[n]
+            if(!sprite.visible) {
+                count--
+                continue
+            }
+
             if (useRotation) {
                 vp = bb._addQuadVerticesFastNormal(
                     vp, vd,

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSpriteContainer.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSpriteContainer.kt
@@ -15,13 +15,18 @@ inline fun Container.fastSpriteContainer(
     callback: @ViewDslMarker FastSpriteContainer.() -> Unit = {}
 ): FastSpriteContainer = FastSpriteContainer(useRotation, smoothing).addTo(this, callback)
 
-class FastSpriteContainer(val useRotation: Boolean = false, var smoothing:Boolean = true) : View() {
+class FastSpriteContainer(val useRotation: Boolean = false, var smoothing: Boolean = true) : View() {
     private val sprites = FastArrayList<FastSprite>()
 
     val numChildren get() = sprites.size
 
     fun addChild(sprite: FastSprite) {
-        sprite.useRotation = useRotation
+        if(sprite.useRotation != useRotation) {
+            sprite.useRotation = useRotation
+            // force update the sprite just in case the FastSprite properties were updated before being
+            // added to the container
+            sprite.forceUpdate()
+        }
         sprite.container = this
         this.sprites.add(sprite)
     }
@@ -96,7 +101,7 @@ class FastSpriteContainer(val useRotation: Boolean = false, var smoothing:Boolea
         for (n in m until mMax) {
             //spriteCount++
             val sprite = sprites[n]
-            if(!sprite.visible) {
+            if (!sprite.visible) {
                 count--
                 continue
             }

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSpriteContainer.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSpriteContainer.kt
@@ -1,20 +1,19 @@
 package com.soywiz.korge.view.fast
 
-import com.soywiz.kds.*
-import com.soywiz.kds.iterators.fastForEach
-import com.soywiz.kmem.FBuffer
-import com.soywiz.korag.*
-import com.soywiz.korge.internal.*
+import com.soywiz.kds.FastArrayList
 import com.soywiz.korge.internal.min2
-import com.soywiz.korge.render.*
-import com.soywiz.korge.view.*
-import kotlin.math.min
+import com.soywiz.korge.render.BatchBuilder2D
+import com.soywiz.korge.render.RenderContext
+import com.soywiz.korge.view.Container
+import com.soywiz.korge.view.View
+import com.soywiz.korge.view.ViewDslMarker
+import com.soywiz.korge.view.addTo
 
 inline fun Container.fastSpriteContainer(
     callback: @ViewDslMarker FastSpriteContainer.() -> Unit = {}
 ): FastSpriteContainer = FastSpriteContainer().addTo(this, callback)
 
-class FastSpriteContainer : View() {
+class FastSpriteContainer() : View() {
     private val sprites = FastArrayList<FastSprite>()
 
     val numChildren get() = sprites.size
@@ -22,6 +21,16 @@ class FastSpriteContainer : View() {
     fun addChild(sprite: FastSprite) {
         this.sprites.add(sprite)
     }
+
+    // alias for addChild
+    fun alloc(sprite: FastSprite) = addChild(sprite)
+
+    fun removeChild(sprite: FastSprite) {
+        this.sprites.remove(sprite)
+    }
+
+    // alias for removeChild
+    fun delete(sprite: FastSprite) = removeChild(sprite)
 
     // 65535 is max vertex index in the index buffer (see ParticleRenderer)
     // so max number of particles is 65536 / 4 = 16384
@@ -82,11 +91,12 @@ class FastSpriteContainer : View() {
         for (n in m until mMax) {
             //spriteCount++
             val sprite = sprites[n]
-            vp = bb._addQuadVerticesFastNormalNonRotated(
+            vp = bb._addQuadVerticesFastNormal(
                 vp, vd,
                 sprite.x0, sprite.y0, sprite.x1, sprite.y1,
+                sprite.x2, sprite.y2, sprite.x3, sprite.y3,
                 sprite.tx0, sprite.ty0, sprite.tx1, sprite.ty1,
-                colorMul, colorAdd
+                sprite.color.value, colorAdd
             )
         }
         bb.vertexPos = vp

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSpriteContainer.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/fast/FastSpriteContainer.kt
@@ -21,6 +21,7 @@ class FastSpriteContainer(val useRotation: Boolean = false) : View() {
 
     fun addChild(sprite: FastSprite) {
         sprite.useRotation = useRotation
+        sprite.container = this
         this.sprites.add(sprite)
     }
 
@@ -29,6 +30,7 @@ class FastSpriteContainer(val useRotation: Boolean = false) : View() {
 
     fun removeChild(sprite: FastSprite) {
         this.sprites.remove(sprite)
+        sprite.container = null
     }
 
     // alias for removeChild

--- a/samples/bunnymark/src/commonMain/kotlin/main.kt
+++ b/samples/bunnymark/src/commonMain/kotlin/main.kt
@@ -8,6 +8,7 @@ import com.soywiz.korio.file.std.*
 import com.soywiz.korge.input.*
 import com.soywiz.korge.render.*
 import com.soywiz.korge.view.fast.FastSprite
+import com.soywiz.korge.view.fast.alpha
 import com.soywiz.korge.view.fast.fastSpriteContainer
 import com.soywiz.korim.bitmap.BmpSlice
 import com.soywiz.korim.bitmap.effect.BitmapEffect
@@ -22,11 +23,8 @@ import kotlin.random.Random
 //}
 
 class Bunny(tex: BmpSlice) : FastSprite(tex) {
-    // Temporal placeholder until FastSpriteContainer supports rotation
-    var rotationRadiansf: Float = 0f
     var speedXf: Float = 0f
     var speedYf: Float = 0f
-    var spinf: Float = 0f
 }
 
 // bunnymark ported from PIXI.js
@@ -63,16 +61,14 @@ suspend fun main() = Korge(width = 800, height = 600, bgcolor = Colors["#2b2b9b"
     fun addBunny(count: Int = 1) {
         for (n in 0 until count) {
             val bunny = Bunny(currentTexture)
-            bunny.speedXf = random.nextFloat() * 10
-            bunny.speedYf = (random.nextFloat() * 10) - 5
+            bunny.speedXf = random.nextFloat() * 1
+            bunny.speedYf = (random.nextFloat() * 1) - 5
             bunny.anchorXf = .5f
             bunny.anchorYf = 1f
-            //bunny.alpha = 0.3 + Math.random() * 0.7;
-            bunny.scalef = 0.5f + random.nextFloat() * 0.5f
+            bunny.alpha = 0.3f + random.nextFloat() * 0.7f
+            bunny.scale(0.5f + random.nextFloat() * 0.5f)
             bunny.rotationRadiansf = (random.nextFloat() - 0.5f)
-            //bunny.rotation = Math.random() - 0.5;
-            //var random = random.nextInt(0, container.numChildren-2);
-            container.addChild(bunny)//, random);
+            container.addChild(bunny)
             bunnys.add(bunny)
         }
         bunnyCountText.text = "(WIP) KorGE Bunnymark. Bunnies: ${bunnys.size}"
@@ -116,7 +112,7 @@ suspend fun main() = Korge(width = 800, height = 600, bgcolor = Colors["#2b2b9b"
             if (bunny.yf > maxY) {
                 bunny.speedYf *= -0.85f
                 bunny.yf = maxY
-                bunny.spinf = (random.nextFloat() - 0.5f) * 0.2f
+                bunny.rotationRadiansf = (random.nextFloat() - 0.5f) * 0.2f
                 if (random.nextFloat() > 0.5) {
                     bunny.speedYf -= random.nextFloat() * 6
                 }

--- a/samples/bunnymark/src/commonMain/kotlin/main.kt
+++ b/samples/bunnymark/src/commonMain/kotlin/main.kt
@@ -1,26 +1,23 @@
-import com.soywiz.kds.*
+import com.soywiz.kds.FastArrayList
 import com.soywiz.kds.iterators.fastForEach
-import com.soywiz.korge.*
-import com.soywiz.korge.view.*
-import com.soywiz.korim.color.*
-import com.soywiz.korim.format.*
-import com.soywiz.korio.file.std.*
-import com.soywiz.korge.input.*
-import com.soywiz.korge.render.*
+import com.soywiz.korge.Korge
+import com.soywiz.korge.input.mouse
+import com.soywiz.korge.render.BatchBuilder2D
+import com.soywiz.korge.view.addUpdater
 import com.soywiz.korge.view.fast.FastSprite
 import com.soywiz.korge.view.fast.alpha
 import com.soywiz.korge.view.fast.fastSpriteContainer
+import com.soywiz.korge.view.position
+import com.soywiz.korge.view.text
 import com.soywiz.korim.bitmap.BmpSlice
 import com.soywiz.korim.bitmap.effect.BitmapEffect
 import com.soywiz.korim.bitmap.sliceWithSize
+import com.soywiz.korim.color.Colors
 import com.soywiz.korim.font.DefaultTtfFont
 import com.soywiz.korim.font.toBitmapFont
+import com.soywiz.korim.format.readBitmap
+import com.soywiz.korio.file.std.resourcesVfs
 import kotlin.random.Random
-
-//class BunnyFastSprite(tex: BmpSlice) : FastSprite(tex) {
-//    var speedX: Float = 0f
-//    var speedY: Float = 0f
-//}
 
 class Bunny(tex: BmpSlice) : FastSprite(tex) {
     var speedXf: Float = 0f
@@ -42,17 +39,13 @@ suspend fun main() = Korge(width = 800, height = 600, bgcolor = Colors["#2b2b9b"
 
     val startBunnyCount = 2
     //val startBunnyCount = 1_000_000
-    //val startBunnyCount = 200_000
+   // val startBunnyCount = 200_000
     val bunnyTextures = listOf(bunny1, bunny2, bunny3, bunny4, bunny5)
     var currentTexture = bunny1
-    val amount = 100
 
-    val container = fastSpriteContainer()
+    val container = fastSpriteContainer(useRotation = true)
     val font = DefaultTtfFont.toBitmapFont(fontSize = 16.0, effect = BitmapEffect(dropShadowX = 1, dropShadowY = 1, dropShadowRadius = 1))
-    //val font = resourcesVfs["font1.fnt"].readBitmapFont()
-    //val font = DefaultTtfFont
     val bunnyCountText = text("", font = font, textSize = 16.0, alignment = com.soywiz.korim.text.TextAlignment.TOP_LEFT).position(16.0, 16.0)
-    //val container = container()
 
     val bunnys = FastArrayList<Bunny>()
 

--- a/samples/bunnymark/src/commonMain/kotlin/main.kt
+++ b/samples/bunnymark/src/commonMain/kotlin/main.kt
@@ -43,7 +43,7 @@ suspend fun main() = Korge(width = 800, height = 600, bgcolor = Colors["#2b2b9b"
     val bunnyTextures = listOf(bunny1, bunny2, bunny3, bunny4, bunny5)
     var currentTexture = bunny1
 
-    val container = fastSpriteContainer(useRotation = true)
+    val container = fastSpriteContainer(useRotation = true, smoothing = false)
     val font = DefaultTtfFont.toBitmapFont(fontSize = 16.0, effect = BitmapEffect(dropShadowX = 1, dropShadowY = 1, dropShadowRadius = 1))
     val bunnyCountText = text("", font = font, textSize = 16.0, alignment = com.soywiz.korim.text.TextAlignment.TOP_LEFT).position(16.0, 16.0)
 


### PR DESCRIPTION
**Context:**
`FastSprite` and `FastSpriteContainer` didn't seem to support setting colors/alpha and rotation. 

**Changes**:
I added support to allow optional rotation calculation for `FastSprite` and `FastSpriteContainer`. It is disabled by default. When it is disabled it uses the previous `BatchBuilder2D` draw call in `FastSpriteContainer`. If it is enabled, `FastSprite` will calculate the vertices based on the rotation.

**Tests**:
I was getting 40 FPS on the JVM target with 200k bunnies before any changes (without rotation). With rotation enabled I am also getting 40 FPS on JVM. with 200k bunnies. Would like to see someone else try this out and see if they get similar results. 