### PR TITLE
Fix 3d

### DIFF
--- a/korge/src/commonMain/kotlin/com/soywiz/korge3d/Shapes3D.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge3d/Shapes3D.kt
@@ -74,13 +74,15 @@ class Cube3D(var width: Double, var height: Double, var depth: Double) : ViewWit
                     val dx = dirs[0]
                     val dy = dirs[1]
 
-                    addVertex(pos - dx - dy, normal, Vector3D(0f, 0f, 0f))
-                    addVertex(pos + dx - dy, normal, Vector3D(1f, 0f, 0f))
-                    addVertex(pos - dx + dy, normal, Vector3D(0f, 1f, 0f))
+                    val i0 = addVertex(pos - dx - dy, normal, Vector3D(0f, 0f, 0f))
+                    val i1 = addVertex(pos + dx - dy, normal, Vector3D(1f, 0f, 0f))
+                    val i2 = addVertex(pos - dx + dy, normal, Vector3D(0f, 1f, 0f))
 
-                    addVertex(pos - dx + dy, normal, Vector3D(0f, 1f, 0f))
-                    addVertex(pos + dx - dy, normal, Vector3D(1f, 0f, 0f))
-                    addVertex(pos + dx + dy, normal, Vector3D(1f, 1f, 0f))
+                    val i3 = addVertex(pos - dx + dy, normal, Vector3D(0f, 1f, 0f))
+                    val i4 = addVertex(pos + dx - dy, normal, Vector3D(1f, 0f, 0f))
+                    val i5 = addVertex(pos + dx + dy, normal, Vector3D(1f, 1f, 0f))
+
+                    addIndices(i0, i1, i2, i3, i4, i5)
                 }
 
                 face(Vector3D(0f, +.5f, 0f))

--- a/korge/src/commonTest/kotlin/com/soywiz/korge3d/MeshTest.kt
+++ b/korge/src/commonTest/kotlin/com/soywiz/korge3d/MeshTest.kt
@@ -1,0 +1,13 @@
+package com.soywiz.korge3d
+
+import kotlin.test.*
+
+@OptIn(Korge3DExperimental::class)
+class MeshTest {
+    @Test
+    fun testCube() {
+        val cube = Cube3D(1.0, 1.0, 1.0)
+        val vertexCount = cube.mesh.vertexCount
+        assertTrue(vertexCount > 0, "cube.mesh.vertexCount(=$vertexCount) is not positive")
+    }
+}


### PR DESCRIPTION
I want to try 3d but I see cubes aren't rendered (Collada models are rendered OK). I've debugged a bit and see that vertex count for cubes is 0, maybe it's the reason. I've just added a test for this (it fails currently), I will try to fix this vertex count later (so please don't merge this PR yet).

Related: korlibs/korge#306, korlibs/korge-samples#35.

Maybe @dhakehurst who reworked 3D (#35) can suggest something here. Maybe also somebody else can comment. I'm a total noob in 3d and even don't understand most of terminology, so it can be quite difficult for me to understand the problem.