### PR TITLE
Add unit test for watch function in resourcesVfs

### DIFF
--- a/korio/src/commonTest/kotlin/com/soywiz/korio/vfs/ResourcesVfsTest.kt
+++ b/korio/src/commonTest/kotlin/com/soywiz/korio/vfs/ResourcesVfsTest.kt
@@ -4,25 +4,37 @@ import com.soywiz.korio.async.*
 import com.soywiz.korio.file.*
 import com.soywiz.korio.file.std.*
 import com.soywiz.korio.util.OS
-import kotlinx.coroutines.channels.*
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.toList
 import kotlin.test.*
 
 class ResourcesVfsTest {
-	@Test
-	fun name() = suspendTest({ OS.isJvm }) {
-		println("[A]")
-		val listing = resourcesVfs["tresfolder"].list()
-		println("[B]")
+    @Test
+    fun name() = suspendTest({ OS.isJvm }) {
+        println("[A]")
+        val listing = resourcesVfs["tresfolder"].list()
+        println("[B]")
 
-		for (v in resourcesVfs["tresfolder"].list().filter { it.extensionLC == "txt" }.toList()) {
-			println(v)
-		}
+        for (v in resourcesVfs["tresfolder"].list().filter { it.extensionLC == "txt" }.toList()) {
+            println(v)
+        }
 
-		assertEquals(
-			"[a.txt, b.txt]",
-			resourcesVfs["tresfolder"].list().filter { it.extensionLC == "txt" }.toList().map { it.baseName }.sorted().toString()
-		)
-	}
+        assertEquals(
+            "[a.txt, b.txt]",
+            resourcesVfs["tresfolder"].list().filter { it.extensionLC == "txt" }.toList().map { it.baseName }.sorted()
+                .toString()
+        )
+    }
+
+    @Test
+    fun watch() = suspendTest({ OS.isJvm }) {
+
+        println("watcher start")
+        launch {
+            resourcesVfs["tresfolder"].watch {
+                println("Watch: $it")
+            }
+        }
+        println("watcher end")
+    }
 }

--- a/korio/src/jvmMain/kotlin/com/soywiz/korio/file/std/LocalVfsJvm.kt
+++ b/korio/src/jvmMain/kotlin/com/soywiz/korio/file/std/LocalVfsJvm.kt
@@ -420,35 +420,37 @@ private class LocalVfsJvm : LocalVfsV2() {
 					val file = rfilepath.toFile()
 					val absolutePath = file.absolutePath
 					val vfsFile = file(absolutePath)
-					when (kind) {
-						StandardWatchEventKinds.OVERFLOW -> {
-							println("Overflow WatchService")
-						}
-						StandardWatchEventKinds.ENTRY_CREATE -> {
-							handler(
-								FileEvent(
-									FileEvent.Kind.CREATED,
-									vfsFile
-								)
-							)
-						}
-						StandardWatchEventKinds.ENTRY_MODIFY -> {
-							handler(
-								FileEvent(
-									FileEvent.Kind.MODIFIED,
-									vfsFile
-								)
-							)
-						}
-						StandardWatchEventKinds.ENTRY_DELETE -> {
-							handler(
-								FileEvent(
-									FileEvent.Kind.DELETED,
-									vfsFile
-								)
-							)
-						}
-					}
+                    withContext(coroutineContext) {
+                        when (kind) {
+                            StandardWatchEventKinds.OVERFLOW -> {
+                                println("Overflow WatchService")
+                            }
+                            StandardWatchEventKinds.ENTRY_CREATE -> {
+                                handler(
+                                    FileEvent(
+                                        FileEvent.Kind.CREATED,
+                                        vfsFile
+                                    )
+                                )
+                            }
+                            StandardWatchEventKinds.ENTRY_MODIFY -> {
+                                handler(
+                                    FileEvent(
+                                        FileEvent.Kind.MODIFIED,
+                                        vfsFile
+                                    )
+                                )
+                            }
+                            StandardWatchEventKinds.ENTRY_DELETE -> {
+                                handler(
+                                    FileEvent(
+                                        FileEvent.Kind.DELETED,
+                                        vfsFile
+                                    )
+                                )
+                            }
+                        }
+                    }
 				}
 
                 if (!key.reset()) {


### PR DESCRIPTION
The added "watch" unit test should pass since the watch call of
resourcesVfs is inside a launch lambda. Currently it fails because of a
bug in LocalVfsJvm.kt (most probably...).

This is for reproducing issue korlibs/korge#727 