### PR TITLE
Fix JS compilation of unsigned stuff

### DIFF
--- a/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/targets/js/JavaScript.kt
+++ b/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/targets/js/JavaScript.kt
@@ -34,7 +34,6 @@ fun Project.configureJavaScript() {
 
 			compilations.all {
 				it.kotlinOptions.apply {
-					languageVersion = "1.4"
 					sourceMap = true
 					//metaInfo = true
 					//moduleKind = "umd"


### PR DESCRIPTION
Fix resolves the problem discussed [here](https://discord.com/channels/728582275884908604/814137887125536838/843998504724463656): compiling `1u` or `toUInt()` crashed with `Type of the constant expression cannot be resolved. Please make sure you have the required dependencies for unsigned types in the classpath` message.