### PR TITLE
Use a default framerate of 60fps if the actual value fails to load

### DIFF
--- a/korgw/src/jvmMain/kotlin/com/soywiz/korgw/awt/AwtExt.kt
+++ b/korgw/src/jvmMain/kotlin/com/soywiz/korgw/awt/AwtExt.kt
@@ -22,7 +22,7 @@ private val cachedRefreshRates = WeakMap<GraphicsDevice, Int>()
 
 val GraphicsDevice.cachedRefreshRate: Int get() {
     return cachedRefreshRates.getOrPut(this) {
-        Console.info("COMPUTED REFRESH RATE for $it")
+        Console.info("COMPUTED REFRESH RATE for $it (${it.displayMode.refreshRate})")
         it.displayMode.refreshRate
     }
 }

--- a/korgw/src/jvmMain/kotlin/com/soywiz/korgw/awt/BaseAwtGameWindow.kt
+++ b/korgw/src/jvmMain/kotlin/com/soywiz/korgw/awt/BaseAwtGameWindow.kt
@@ -666,7 +666,6 @@ abstract class BaseAwtGameWindow : GameWindow() {
     }
 
     override fun computeDisplayRefreshRate(): Int {
-        val window = this.window ?: return 60
-        return window.getScreenDevice().cachedRefreshRate
+        return window?.getScreenDevice()?.cachedRefreshRate?.takeIf { it > 0 } ?: 60
     }
 }


### PR DESCRIPTION
On Linux the X11GraphicsDevice implementation will return a refresh rate of 0 if it couldn't get the current display mode for whatever reason.