### PR TITLE
Fix loading tiledmap into given atlas

### DIFF
--- a/korge/src/commonMain/kotlin/com/soywiz/korge/tiled/TiledMapReader.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/tiled/TiledMapReader.kt
@@ -64,7 +64,11 @@ suspend fun TileSetData.toTiledSet(
 	createBorder: Int = 1,
     atlas: MutableAtlasUnit? = null
 ): TiledTileset {
-    val atlas = if (atlas == null || createBorder > 0) MutableAtlasUnit(2048, border = createBorder.clamp(2, 4)) else null
+    val atlas = when {
+        atlas != null -> atlas
+        createBorder > 0 -> MutableAtlas(2048, border = createBorder.clamp(1, 4))
+        else -> null
+    }
 
 	val tileset = this
 	var bmp = try {


### PR DESCRIPTION
When specifying an atlas object with calling readTiledMap then all tiles
from the tiled map are now included in the atlas texture.

This fixes #332