### PR TITLE
Fix KorIM crashes when running in native

### DIFF
--- a/korim/src/linuxArm32HfpMain/kotlin/com/soywiz/korim/font/NativeSystemFontProviderFallback.kt
+++ b/korim/src/linuxArm32HfpMain/kotlin/com/soywiz/korim/font/NativeSystemFontProviderFallback.kt
@@ -1,6 +1,3 @@
 package com.soywiz.korim.font
 
-import kotlin.native.concurrent.*
-
-@ThreadLocal
 actual val nativeSystemFontProvider: NativeSystemFontProvider = FolderBasedNativeSystemFontProvider()

--- a/korim/src/linuxX64Main/kotlin/com/soywiz/korim/font/NativeSystemFontProviderFallback.kt
+++ b/korim/src/linuxX64Main/kotlin/com/soywiz/korim/font/NativeSystemFontProviderFallback.kt
@@ -1,6 +1,3 @@
 package com.soywiz.korim.font
 
-import kotlin.native.concurrent.*
-
-@ThreadLocal
 actual val nativeSystemFontProvider: NativeSystemFontProvider = FolderBasedNativeSystemFontProvider()


### PR DESCRIPTION
KorIM is crashing with the addition of `@ThreadLocal` on `nativeSystemFontProvider`.  Removing the annotation fixed the crash.

Crash:
```
Uncaught Kotlin exception: kotlin.native.IncorrectDereferenceException: Trying to access top level value not marked as @ThreadLocal or @SharedImmutable from non-main thread
    at kfun:kotlin.Throwable#<init>(kotlin.String?){} (0x2ce68)
    at kfun:kotlin.Exception#<init>(kotlin.String?){} (0x2584c)
    at kfun:kotlin.RuntimeException#<init>(kotlin.String?){} (0x259f8)
    at kfun:kotlin.native.IncorrectDereferenceException#<init>(kotlin.String){} (0x58c10)
    at ThrowIncorrectDereferenceException (0x72efc)
    at CheckGlobalsAccessible (0xcdda28)
    at kfun:com.soywiz.korim.font.<get-linuxFolders>#internal (0x482e2c)
    at kfun:com.soywiz.korim.font.FolderBasedNativeSystemFontProvider#<init>(kotlin.collections.List<kotlin.String>?;kotlin.String?;kotlin.Int;kotlin.native.internal.DefaultConstructorMarker?){} (0x484884)
    at  (0xb9599c)
```