### PR TITLE
Fix AM/PM parsing bug when hour is 12, and ignore case of AM/PM in parsed string

### DIFF
--- a/klock/src/commonMain/kotlin/com/soywiz/klock/PatternDateFormat.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/PatternDateFormat.kt
@@ -259,15 +259,23 @@ data class PatternDateFormat @JvmOverloads constructor(
                 }
                 "MMMM" -> month = realLocale.months.indexOf(value) + 1
                 "MMMMM" -> if (doThrow) throw RuntimeException("Not possible to get the month from one letter.") else return null
-                "a" -> isPm = value == "pm"
+                "a" -> isPm = value.equals("pm", ignoreCase = true)
                 else -> {
                     // ...
                 }
             }
         }
         //return DateTime.createClamped(fullYear, month, day, hour, minute, second)
-        if (is12HourFormat && isPm) {
-            hour += 12
+        if (is12HourFormat) {
+            if (isPm) {
+                if (hour != 12) {
+                    hour += 12
+                }
+            } else {
+                if (hour == 12) {
+                    hour = 0
+                }
+            }
         }
         val dateTime = DateTime.createAdjusted(fullYear, month, day, hour, minute, second, millisecond)
         return dateTime.toOffsetUnadjusted(offset ?: 0.hours)

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/DateTimeTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/DateTimeTest.kt
@@ -280,6 +280,17 @@ class DateTimeTest {
     }
 
     @Test
+    fun testParseAmPmFormat() {
+        val format = DateFormat("MMM d, yyyy h:mm:ss a")
+
+        assertEquals("Tue, 07 Sep 2021 12:50:08 UTC", HttpDate.format(format.parse("Sep 7, 2021 12:50:08 pm")))
+        assertEquals("Tue, 07 Sep 2021 13:50:08 UTC", HttpDate.format(format.parse("Sep 7, 2021 1:50:08 PM")))
+        assertEquals("Tue, 07 Sep 2021 00:50:08 UTC", HttpDate.format(format.parse("Sep 7, 2021 12:50:08 am")))
+        assertEquals("Tue, 07 Sep 2021 00:00:00 UTC", HttpDate.format(format.parse("Sep 7, 2021 12:00:00 am")))
+        assertEquals("Tue, 07 Sep 2021 12:00:00 UTC", HttpDate.format(format.parse("Sep 7, 2021 12:00:00 pm")))
+    }
+
+    @Test
     fun testCheckedCreation() {
         assertEquals("Mon, 18 Sep 2017 23:58:45 UTC", HttpDate.format(DateTime(2017, 9, 18, 23, 58, 45)))
     }


### PR DESCRIPTION
Fix AM/PM parsing bug when hour is 12, and ignore case of AM/PM in parsed string.