### PR TITLE
Make addUpdater configurable in ParallaxDataView

### DIFF
--- a/samples/parallax-scrolling-aseprite/src/commonMain/kotlin/main.kt
+++ b/samples/parallax-scrolling-aseprite/src/commonMain/kotlin/main.kt
@@ -11,7 +11,6 @@ import com.soywiz.korge.view.animation.*
 import com.soywiz.korge.view.filter.TransitionFilter
 import com.soywiz.korim.atlas.MutableAtlasUnit
 import com.soywiz.korim.color.Colors
-import com.soywiz.korim.format.ASE
 import com.soywiz.korio.async.launch
 import com.soywiz.korio.file.Vfs
 import com.soywiz.korio.file.fullName


### PR DESCRIPTION
(I saw that you are currently on vacation. Don't worry, this PR can wait.
Please relax, recharge your batteries and have great holidays.)

The ParallaxDataView will add an "updater" to each of its view
which scrolls depending to the game playfield. Sometimes the parallax
view should not scroll automatically but the position should be set
directly. E.g. when using parallax backgrounds in an intro or similar
where it is needed to have more "control" over the movement of the
background.

Thus this commit makes adding the "addUpdater" lambda configurable per X
and Y scrolling direction.