### PR TITLE
Fix updating frame index in ImageAnimationView

### DIFF
--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/animation/ImageAnimationView.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/animation/ImageAnimationView.kt
@@ -70,7 +70,7 @@ open class ImageAnimationView<T: SmoothedBmpSlice>(
             dir = when (computedDirection) {
                 ImageAnimation.Direction.FORWARD -> +1
                 ImageAnimation.Direction.REVERSE -> -1
-                ImageAnimation.Direction.PING_PONG -> if (frame.index + dir !in 0 until nframes) -dir else dir
+                ImageAnimation.Direction.PING_PONG -> if (frameIndex + dir !in 0 until nframes) -dir else dir
             }
             nextFrameIndex = (frameIndex + dir) umod nframes
         } else {

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/animation/ImageAnimationView.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/animation/ImageAnimationView.kt
@@ -63,7 +63,6 @@ open class ImageAnimationView<T: SmoothedBmpSlice>(
             frame.layerData.fastForEach {
                 val image = layers[it.layer.index]
                 image.bitmap = it.slice
-                image.smoothing = smoothing
                 (image as View).xy(it.targetX, it.targetY)
             }
             nextFrameIn = frame.duration
@@ -95,6 +94,7 @@ open class ImageAnimationView<T: SmoothedBmpSlice>(
         if (animation != null) {
             for (layer in animation.layers) {
                 val image = createImage()
+                image.smoothing = smoothing
                 layers.add(image)
                 layersByName[layer.name ?: "default"] = image
                 addChild(image as View)

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/animation/ImageAnimationView.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/animation/ImageAnimationView.kt
@@ -72,7 +72,7 @@ open class ImageAnimationView<T: SmoothedBmpSlice>(
                 ImageAnimation.Direction.REVERSE -> -1
                 ImageAnimation.Direction.PING_PONG -> if (frame.index + dir !in 0 until nframes) -dir else dir
             }
-            nextFrameIndex = (frame.index + dir) umod nframes
+            nextFrameIndex = (frameIndex + dir) umod nframes
         } else {
             layers.fastForEach { it.bitmap = Bitmaps.transparent }
         }

--- a/korge/src/commonTest/kotlin/com/soywiz/korge/view/ImageAnimationViewTest.kt
+++ b/korge/src/commonTest/kotlin/com/soywiz/korge/view/ImageAnimationViewTest.kt
@@ -1,0 +1,64 @@
+package com.soywiz.korge.view
+
+import com.soywiz.klock.milliseconds
+import com.soywiz.korge.view.animation.ImageAnimationView
+import com.soywiz.korim.bitmap.Bitmaps
+import com.soywiz.korim.format.ImageAnimation
+import com.soywiz.korim.format.ImageFrame
+import com.soywiz.korim.format.ImageFrameLayer
+import com.soywiz.korim.format.ImageLayer
+import kotlin.test.*
+
+class ImageAnimationViewTest {
+    private val animImages4Layers1 = ImageAnimation(
+        frames = listOf(
+            ImageFrame(0, 60.milliseconds, listOf(ImageFrameLayer(ImageLayer(0, "layer0"), Bitmaps.transparent, 1))),
+            ImageFrame(1, 60.milliseconds, listOf(ImageFrameLayer(ImageLayer(0, "layer0"), Bitmaps.transparent, 2))),
+            ImageFrame(2, 60.milliseconds, listOf(ImageFrameLayer(ImageLayer(0, "layer0"), Bitmaps.transparent, 3))),
+            ImageFrame(3, 60.milliseconds, listOf(ImageFrameLayer(ImageLayer(0, "layer0"), Bitmaps.transparent, 4)))
+        ),
+        direction = ImageAnimation.Direction.FORWARD,
+        name = "anim1",
+        layers = listOf(ImageLayer(0, "layer0"))
+    )
+    private val animImages6Layers2 = ImageAnimation(
+        frames = listOf(
+            ImageFrame(10, 60.milliseconds, listOf(ImageFrameLayer(ImageLayer(0, "layer0"), Bitmaps.transparent, 1), ImageFrameLayer(ImageLayer(1, "layer1"), Bitmaps.transparent, 10))),
+            ImageFrame(12, 60.milliseconds, listOf(ImageFrameLayer(ImageLayer(0, "layer0"), Bitmaps.transparent, 2), ImageFrameLayer(ImageLayer(1, "layer1"), Bitmaps.transparent, 20))),
+            ImageFrame(11, 60.milliseconds, listOf(ImageFrameLayer(ImageLayer(0, "layer0"), Bitmaps.transparent, 3), ImageFrameLayer(ImageLayer(1, "layer1"), Bitmaps.transparent, 30))),
+            ImageFrame(13, 60.milliseconds, listOf(ImageFrameLayer(ImageLayer(0, "layer0"), Bitmaps.transparent, 4), ImageFrameLayer(ImageLayer(1, "layer1"), Bitmaps.transparent, 40))),
+            ImageFrame(14, 60.milliseconds, listOf(ImageFrameLayer(ImageLayer(0, "layer0"), Bitmaps.transparent, 5), ImageFrameLayer(ImageLayer(1, "layer1"), Bitmaps.transparent, 50))),
+            ImageFrame(15, 60.milliseconds, listOf(ImageFrameLayer(ImageLayer(0, "layer0"), Bitmaps.transparent, 6), ImageFrameLayer(ImageLayer(1, "layer1"), Bitmaps.transparent, 60)))
+        ),
+        direction = ImageAnimation.Direction.REVERSE,
+        name = "anim2",
+        layers = listOf(ImageLayer(0, "layer0"), ImageLayer(1, "layer1"))
+    )
+    private val anim = ImageAnimationView { Image(Bitmaps.transparent) }
+
+    @Test
+    fun testNumberOfChildren() {
+        // Test if correct number of layers are added as children to the Container
+        anim.animation = animImages4Layers1
+        assertEquals(1, anim.children.size)
+        anim.animation = animImages6Layers2
+        assertEquals(2, anim.children.size)
+    }
+
+    @Test
+    fun testSetFirstFrame() {
+        // Test if the correct frame is set as first frame
+        // Here we check if the corresponding targetX value was set as X position of the layer.
+        anim.animation = animImages4Layers1
+        assertEquals(1, anim.children[0].x.toInt())
+        anim.direction = ImageAnimation.Direction.REVERSE
+        anim.rewind()
+        assertEquals(4, anim.children[0].x.toInt())
+        anim.animation = animImages6Layers2
+        assertEquals(6, anim.children[0].x.toInt())
+        assertEquals(60, anim.children[1].x.toInt())
+    }
+
+//        println("children: ${imageanimView.children.size}")
+
+}

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/format/ImageFrame.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/format/ImageFrame.kt
@@ -4,6 +4,14 @@ import com.soywiz.kds.*
 import com.soywiz.klock.*
 import com.soywiz.korim.bitmap.*
 
+/**
+ * This class defines one frame of a sprite object like e.g. an aseprite image file.
+ * It contains info about all layer images which are used in that frame.
+ *
+ * @param index The index of the frame within the sprite (e.g. aseprite file).
+ * @param time  When this frame is used in an animation this defines the time the frame should be displayed.
+ * @param layerData This is a list of all layers which this frame contains.
+ */
 open class ImageFrame(
     val index: Int,
     val time: TimeSpan = 0.seconds,

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/format/ImageFrameLayer.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/format/ImageFrameLayer.kt
@@ -2,6 +2,18 @@ package com.soywiz.korim.format
 
 import com.soywiz.korim.bitmap.*
 
+/**
+ * This class is used to store the layer image from e.g. an aseprite image file.
+ *
+ * @param layer   Stores the index and the name of the layer.
+ * @param slice   This is the actual bitmap image.
+ * @param targetX X offset in pixel from the top left corner of the overall image.
+ * @param targetY Y offset in pixel from the top left corner of the overall image.
+ * Offsets are used to crop empty space around the sprite images.
+ *
+ * [...]
+ *
+ */
 open class ImageFrameLayer constructor(
     val layer: ImageLayer,
     slice: BmpSlice,


### PR DESCRIPTION
For getting nextFrameIndex the prior index is saved in frameIndex and
not in "frame.index" which is the number of the frame within ImageData
frame list.

I found this while having two longer animations in my ase file. The second
animation was not played properly. It looked that the frames are jumping
in random order. You don't realize this effect in the korge-starter-kit-rpg sprites
since the animations for the sprites are only 3 frames long.