### PR TITLE
Add test case for datetime formatting

### DIFF
--- a/klock/src/commonTest/kotlin/com/soywiz/klock/DateFormatTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/DateFormatTest.kt
@@ -8,4 +8,12 @@ class DateFormatTest {
         assertEquals("Sat, 03 Dec 2011 10:15:30 GMT+0100", DateFormat.FORMAT1.parse("2011-12-03T10:15:30+01:00").toStringDefault())
         assertEquals("Sat, 03 Dec 2011 10:15:30 GMT+0100", DateFormat.FORMAT1.parse("2011-12-03T10:15:30+0100").toStringDefault())
     }
+
+    @Test
+    fun testTimeStampFormatting() {
+        val timeStamp01012020 = 1577836800000
+        val formattedTimeStamp = DateFormat("YYYY-MM-dd hh:mm:ss").format(timeStamp01012020)
+
+        assertEquals("2020-01-01 00:00:00", formattedTimeStamp)
+    }
 }


### PR DESCRIPTION
I believe this to be a bug but I am not 100% sure.

I create a unix timestamp for 01-01-2020 00:00:00 and then format it. The result is off by 12 hours. 

 `expected:<2020-01-01 [00]:00:00> but was:<2020-01-01 [12]:00:00>`
