### PR TITLE
Updated buildscripts to add iosSimulatorArm64 target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,7 +91,8 @@ val KotlinTarget.isMacosArm64 get() = this.name == "macosArm64"
 val KotlinTarget.isMacos get() = isMacosX64 || isMacosArm64
 val KotlinTarget.isIosArm64 get() = this.name == "iosArm64"
 val KotlinTarget.isIosX64 get() = this.name == "iosX64"
-val KotlinTarget.isIos get() = isIosArm64 || isIosX64
+val KotlinTarget.isIosSimulatorArm64 get() = this.name == "iosSimulatorArm64"
+val KotlinTarget.isIos get() = isIosArm64 || isIosX64 || isIosSimulatorArm64
 val KotlinTarget.isWatchosX86 get() = this.name == "watchosX86"
 val KotlinTarget.isWatchosArm32 get() = this.name == "watchosArm32"
 val KotlinTarget.isWatchosArm64 get() = this.name == "watchosArm64"
@@ -148,7 +149,7 @@ fun org.jetbrains.kotlin.gradle.dsl.KotlinTargetContainerWithPresetFunctions.nat
 }
 
 fun org.jetbrains.kotlin.gradle.dsl.KotlinTargetContainerWithPresetFunctions.mobileTargets(): List<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget> {
-    return listOf(iosArm64(), iosX64())
+    return listOf(iosArm64(), iosX64(), iosSimulatorArm64())
 }
 
 //apply(from = "${rootProject.rootDir}/build.idea.gradle")

--- a/korge-gradle-plugin/@old/src/main/kotlin/com/soywiz/korge/gradle/targets/ios/Ios.kt
+++ b/korge-gradle-plugin/@old/src/main/kotlin/com/soywiz/korge/gradle/targets/ios/Ios.kt
@@ -37,7 +37,7 @@ fun Project.configureNativeIos() {
 	}
 
 	kotlin.apply {
-		for (target in listOf(iosX64(), iosArm64())) {
+		for (target in listOf(iosX64(), iosArm64(), iosSimulatorArm64())) {
 			//for (target in listOf(iosX64())) {
 			target.also { target ->
 				//target.attributes.attribute(KotlinPlatformType.attribute, KotlinPlatformType.native)

--- a/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/KorgeExtension.kt
+++ b/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/KorgeExtension.kt
@@ -465,7 +465,7 @@ class KorgeExtension(val project: Project) {
 		}
 	}
 
-	val ALL_NATIVE_TARGETS by lazy { listOf("iosArm64", "iosX64") + project.DESKTOP_NATIVE_TARGETS }
+	val ALL_NATIVE_TARGETS by lazy { listOf("iosArm64", "iosX64", "iosSimulatorArm64") + project.DESKTOP_NATIVE_TARGETS }
 	//val ALL_TARGETS = listOf("android", "js", "jvm", "metadata") + ALL_NATIVE_TARGETS
 	val ALL_TARGETS by lazy { listOf("js", "jvm", "metadata") + ALL_NATIVE_TARGETS }
 

--- a/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/targets/ios/Ios.kt
+++ b/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/targets/ios/Ios.kt
@@ -54,7 +54,7 @@ fun Project.configureNativeIos() {
 		}
 	}
 
-    val iosTargets = listOf(kotlin.iosX64(), kotlin.iosArm64())
+    val iosTargets = listOf(kotlin.iosX64(), kotlin.iosArm64(), kotlin.iosSimulatorArm64())
 
 	kotlin.apply {
 		for (target in iosTargets) {

--- a/korge-gradle-plugin/src2/main/kotlin/com/soywiz/korge/gradle/KorgeExtension.kt
+++ b/korge-gradle-plugin/src2/main/kotlin/com/soywiz/korge/gradle/KorgeExtension.kt
@@ -38,6 +38,7 @@ class KorgeExtension(val project: Project) {
     fun ios() {
         iosArm64()
         iosX64()
+        iosSimulatorArm64()
     }
     fun tvos() {
         tvosArm64()
@@ -52,6 +53,7 @@ class KorgeExtension(val project: Project) {
 
     fun iosArm64() = project.kotlin.iosArm64().korgeConfigure()
     fun iosX64() = project.kotlin.iosX64().korgeConfigure()
+    fun iosSimulatorArm64() = project.kotlin.iosSimulatorArm64().korgeConfigure()
 
     fun tvosArm64() = project.kotlin.tvosArm64().korgeConfigure()
     fun tvosX64() = project.kotlin.tvosX64().korgeConfigure()


### PR DESCRIPTION
Problem: building for the iOS simulator on an Apple M1 machine would not work.
Solution: added the required iosSimulatorArm64 targets. I've tested using krypto and klock and it works perfectly.

Can someone please take a look if we think we need anything else?