### PR TITLE
Implement playing image animation only once

### DIFF
--- a/korim/src/commonMain/kotlin/com/soywiz/korim/format/ImageAnimation.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/format/ImageAnimation.kt
@@ -6,5 +6,5 @@ open class ImageAnimation(
     val name: String,
     val layers: List<ImageLayer> = frames.flatMap { it.layerData }.map { it.layer }.distinct().sortedBy { it.index }
 ) {
-    enum class Direction { FORWARD, REVERSE, PING_PONG }
+    enum class Direction { ONCE_FORWARD, ONCE_REVERSE, FORWARD, REVERSE, PING_PONG }
 }

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/format/ImageData.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/format/ImageData.kt
@@ -21,7 +21,7 @@ open class ImageData constructor(
             animations: List<ImageAnimation> = fastArrayListOf(),
             name: String? = null,
         ): ImageData =
-            ImageData(animations.first().frames, loopCount = loopCount, layers = layers, animations = animations, name = name)
+            ImageData(frames = fastArrayListOf(), loopCount = loopCount, layers = layers, animations = animations, name = name)
     }
 
     val defaultAnimation = ImageAnimation(frames, ImageAnimation.Direction.FORWARD, "default")


### PR DESCRIPTION
This commit implements playing an image animation only one forward or
reverse. For that it is possible to set the direction to ONCE_FORWARD or
ONCE_REVERSE. If direction is "ONCE_*" then when playing has finished
the call-back onPlayFinished() will be invoked. With that is is possible
to react on finished animation playing like scrap the animationView
object or reset it to be used again.

Also there was a second call-back added: onDestroyLayer()
That is invoked when the layers of the animation view gets deleted
because the animation is changed to another in ImageData. That call-back
can be used to recycle the image objects which are used for the image
animation view layers.