### PR TITLE
jvmTest on e2e-test on mac seems to be flaky due to timeout,

### DIFF
--- a/.github/workflows/TEST.yml
+++ b/.github/workflows/TEST.yml
@@ -108,7 +108,8 @@ jobs:
         run: ./gradlew --no-daemon publishJvmLocal publishMacosX64PublicationToMavenLocal
       - name: e2e test
         working-directory: e2e-test
-        run: "./gradlew jvmTest runJvmCheckReferences"
+        run: "./gradlew runJvmCheckReferences"
+        #run: "./gradlew jvmTest runJvmCheckReferences"
 
   test-native-windows:
     timeout-minutes: 120


### PR DESCRIPTION
since it is jvm-only and it is being executed on windows, let's disable it for now