### PR TITLE
Update Fleks ECS

### DIFF
--- a/korge-fleks/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
+++ b/korge-fleks/src/commonMain/kotlin/com/github/quillraven/fleks/system.kt
@@ -149,13 +149,13 @@ abstract class IteratingSystem(
 ) : IntervalSystem(interval, enabled) {
     /**
      * Returns the [family][Family] of this system.
-     * This reference gets updated by the [SystemService] when the system gets created via reflection.
+     * This reference gets updated by the [SystemService] when the system gets created via the SystemFactory.
      */
     internal lateinit var family: Family
 
     /**
      * Returns the [entityService][EntityService] of this system.
-     * This reference gets updated by the [SystemService] when the system gets created via reflection.
+     * This reference gets updated by the [SystemService] when the system gets created via the SystemFactory.
      */
     @PublishedApi
     internal lateinit var entityService: EntityService

--- a/korge-fleks/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
+++ b/korge-fleks/src/commonMain/kotlin/com/github/quillraven/fleks/world.kt
@@ -52,26 +52,34 @@ class WorldConfiguration {
     /**
      * Adds the specified [dependency] under the given [type] which can then be injected to any [IntervalSystem] or [ComponentListener].
      *
+     * @param type is the name of the dependency which is used to access it in systems and listeners. This is especially useful if two or more
+     *             dependency objects of the same type shall be injected.
+     * @param dependency object which shall be injected to systems and listeners of the Fleks ECS.
+     * @param used this will set the injected dependency to [used] internally. Default is false. If set to true then Fleks will not
+     *             complain if the dependency is not used by any system or listener on their creation time.
      * @throws [FleksInjectableAlreadyAddedException] if the dependency was already added before.
      */
-    fun <T : Any> inject(type: String, dependency: T) {
+    fun <T : Any> inject(type: String, dependency: T, used: Boolean = false) {
         if (type in injectables) {
             throw FleksInjectableAlreadyAddedException(type)
         }
 
-        injectables[type] = Injectable(dependency)
+        injectables[type] = Injectable(dependency, used)
     }
 
     /**
      * Adds the specified dependency which can then be injected to any [IntervalSystem] or [ComponentListener].
      * Refer to [inject]: the type is the simpleName of the class of the [dependency].
      *
+     * @param dependency object which shall be injected to systems and listeners of the Fleks ECS.
+     * @param used this will set the injected dependency to [used] internally. Default is false. If set to true then Fleks will not
+     *             complain if the dependency is not used by any system or listener on their creation time.
      * @throws [FleksInjectableAlreadyAddedException] if the dependency was already added before.
      * @throws [FleksInjectableTypeHasNoName] if the dependency type has no T::class.simpleName.
      */
-    inline fun <reified T : Any> inject(dependency: T) {
+    inline fun <reified T : Any> inject(dependency: T, used: Boolean = false) {
         val type = T::class.simpleName ?: throw FleksInjectableTypeHasNoName(T::class)
-        inject(type, dependency)
+        inject(type, dependency, used)
     }
 
     /**

--- a/samples/fleks-ecs/src/commonMain/kotlin/entities/Explosions.kt
+++ b/samples/fleks-ecs/src/commonMain/kotlin/entities/Explosions.kt
@@ -15,7 +15,7 @@ fun World.createExplosionArtefact(position: Position, destruct: Destruct) {
                 y += (-destruct.explosionParticleRange..destruct.explosionParticleRange).random()
             }
             // make sure that all spawned objects are above 200 - this is hardcoded for now since we only have some basic collision detection at y > 200
-            // otherwise they will be destroyed immediately and false appear at position 0x0
+            // otherwise the explosion artefacts will be destroyed immediately and appear at position 0x0 for one frame
             if (y > 200.0) { y = 199.0 }
             xAcceleration = position.xAcceleration + random(destruct.explosionParticleAcceleration)
             yAcceleration = -position.yAcceleration + random(destruct.explosionParticleAcceleration)


### PR DESCRIPTION
New feature was added which makes it possible to mark an injectable as
"used". Thus Fleks will not throw exception if the injectable is not
used directly at creation of system and listener objects. That means it
is now possible to use the injected objects during init functions. Default
for "used" option is "false". Which has the same effect as before.