### PR TITLE
Proper gpu-vector fill rendering

### DIFF
--- a/korge/src/commonTest/kotlin/com/soywiz/korge3d/Matrix3DTest.kt
+++ b/korge/src/commonTest/kotlin/com/soywiz/korge3d/Matrix3DTest.kt
@@ -114,4 +114,11 @@ class Matrix3DTest {
     fun round(x: Float, digits: Int) = (round(x * 10.0.pow(digits)) / 10.0.pow(digits)).toFloat()
     fun round(x: Double, digits: Int) = round(x * 10.0.pow(digits)) / 10.0.pow(digits)
 
+    @Test
+    fun testConvert() {
+        val mat = Matrix().translate(100, 20).scale(2, 2)
+        assertEquals(Point(240, 60), mat.transform(Point(20, 10)))
+        val m3d = mat.toMatrix3D()
+        assertEquals(Vector3D(240, 60, 0, 1), m3d.transform(Vector3D(20, 10, 0, 1)))
+    }
 }

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/color/RGBA.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/color/RGBA.kt
@@ -15,7 +15,6 @@ import com.soywiz.korma.interpolation.interpolate
 import com.soywiz.krypto.encoding.*
 
 inline class RGBA(val value: Int) : Comparable<RGBA>, Interpolable<RGBA>, Paint {
-    override fun transformed(m: Matrix): Paint = this
     override fun clone(): Paint = this
     val color: RGBA get() = this
 

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/color/RGBA.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/color/RGBA.kt
@@ -16,6 +16,7 @@ import com.soywiz.krypto.encoding.*
 
 inline class RGBA(val value: Int) : Comparable<RGBA>, Interpolable<RGBA>, Paint {
     override fun transformed(m: Matrix): Paint = this
+    override fun clone(): Paint = this
     val color: RGBA get() = this
 
     val r: Int get() = value.extract8(RED_OFFSET)

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/paint/Paint.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/paint/Paint.kt
@@ -11,12 +11,10 @@ import kotlin.apply
 import kotlin.math.*
 
 interface Paint {
-    fun transformed(m: Matrix): Paint
     fun clone(): Paint
 }
 
 object NonePaint : Paint {
-    override fun transformed(m: Matrix) = this
     override fun clone(): Paint = this
 }
 
@@ -189,7 +187,6 @@ data class GradientPaint(
 
     fun applyMatrix(m: Matrix): GradientPaint = copy(transform = transform * m)
 
-    override fun transformed(m: Matrix) = applyMatrix(m)
     override fun clone(): Paint = copy(transform = transform.clone())
 
     override fun toString(): String = when (kind) {
@@ -221,7 +218,6 @@ data class BitmapPaint(
     val repeat: Boolean get() = repeatX || repeatY
 
     val bmp32 = bitmap.toBMP32()
-    override fun transformed(m: Matrix) = copy(transform = Matrix().multiply(m, this.transform))
     override fun clone(): Paint = copy(transform = transform.clone())
 
     //override fun transformed(m: Matrix) = BitmapPaint(bitmap, Matrix().multiply(this.transform, m))

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/paint/Paint.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/paint/Paint.kt
@@ -12,10 +12,12 @@ import kotlin.math.*
 
 interface Paint {
     fun transformed(m: Matrix): Paint
+    fun clone(): Paint
 }
 
 object NonePaint : Paint {
     override fun transformed(m: Matrix) = this
+    override fun clone(): Paint = this
 }
 
 typealias ColorPaint = RGBA
@@ -165,9 +167,6 @@ data class GradientPaint(
             GradientKind.RADIAL -> {
                 val x = transformInv.transformX(px, py)
                 val y = transformInv.transformY(px, py)
-                //val x = px
-                //val y = py
-                //1.0 - (-r1 * (r0 - r1) + (x0 - x1) * (x1 - x) + (y0 - y1) * (y1 - y) - sqrt(r1.pow2 * ((x0 - x).pow2 + (y0 - y).pow2) - 2 * r0 * r1 * ((x0 - x) * (x1 - x) + (y0 - y) * (y1 - y)) + r0.pow2 * ((x1 - x).pow2 + (y1 - y).pow2) - (x1 * y0 - x * y0 - x0 * y1 + x * y1 + x0 * y - x1 * y).pow2)) / ((r0 - r1).pow2 - (x0 - x1).pow2 - (y0 - y1).pow2)
                 1.0 - (-r1 * r0_r1 + x0_x1 * (x1 - x) + y0_y1 * (y1 - y) - sqrt(r1pow2 * ((x0 - x).pow2 + (y0 - y).pow2) - r0r1_2 * ((x0 - x) * (x1 - x) + (y0 - y) * (y1 - y)) + r0pow2 * ((x1 - x).pow2 + (y1 - y).pow2) - (x1 * y0 - x * y0 - x0 * y1 + x * y1 + x0 * y - x1 * y).pow2)) * radial_scale
             }
             else -> {
@@ -205,6 +204,7 @@ data class GradientPaint(
     )
 
     override fun transformed(m: Matrix) = applyMatrix(m)
+    override fun clone(): Paint = copy(transform = transform.clone())
 
     override fun toString(): String = when (kind) {
         GradientKind.LINEAR -> "LinearGradient($x0, $y0, $x1, $y1, $stops, $colors)"
@@ -223,7 +223,7 @@ inline fun RadialGradientPaint(x0: Number, y0: Number, r0: Number, x1: Number, y
 @Deprecated("Only available on Android or Bitmap32")
 inline fun SweepGradientPaint(x0: Number, y0: Number, transform: Matrix = Matrix()) = GradientPaint(GradientKind.SWEEP, x0.toDouble(), y0.toDouble(), 0.0, 0.0, 0.0, 0.0, transform = transform)
 
-class BitmapPaint(
+data class BitmapPaint(
     val bitmap: Bitmap,
     override val transform: Matrix,
     val cycleX: CycleMethod = CycleMethod.NO_CYCLE,
@@ -235,7 +235,8 @@ class BitmapPaint(
     val repeat: Boolean get() = repeatX || repeatY
 
     val bmp32 = bitmap.toBMP32()
-    override fun transformed(m: Matrix) = BitmapPaint(bitmap, Matrix().multiply(m, this.transform))
+    override fun transformed(m: Matrix) = copy(transform = Matrix().multiply(m, this.transform))
+    override fun clone(): Paint = copy(transform = transform.clone())
 
     //override fun transformed(m: Matrix) = BitmapPaint(bitmap, Matrix().multiply(this.transform, m))
     override fun toString(): String = "BitmapPaint($bitmap, cycle=($cycleX, $cycleY), smooth=$smooth, transform=$transform)"

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/paint/Paint.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/paint/Paint.kt
@@ -187,21 +187,7 @@ data class GradientPaint(
         //return getRatioAt(x, y)
     }
 
-    fun applyMatrix(m: Matrix): GradientPaint = GradientPaint(
-        kind,
-        m.transformX(x0, y0),
-        m.transformY(x0, y0),
-        r0 * m.transformX(1.0, 0.0),
-        m.transformX(x1, y1),
-        m.transformY(x1, y1),
-        r1 * m.transformX(1.0, 0.0),
-        DoubleArrayList(stops),
-        IntArrayList(colors),
-        cycle,
-        Matrix(),
-        interpolationMethod,
-        units
-    )
+    fun applyMatrix(m: Matrix): GradientPaint = copy(transform = transform * m)
 
     override fun transformed(m: Matrix) = applyMatrix(m)
     override fun clone(): Paint = copy(transform = transform.clone())

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/vector/Shape.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/vector/Shape.kt
@@ -138,6 +138,7 @@ interface StyledShape : Shape {
 	val clip: GraphicsPath?
 	val paint: Paint
 	val transform: Matrix
+    val globalAlpha: Double
 
 	override fun addBounds(bb: BoundsBuilder, includeStrokes: Boolean): Unit {
         path?.let { path ->
@@ -310,7 +311,8 @@ data class FillShape(
     override val path: GraphicsPath,
     override val clip: GraphicsPath?,
     override val paint: Paint,
-    override val transform: Matrix = Matrix()
+    override val transform: Matrix = Matrix(),
+    override val globalAlpha: Double = 1.0,
 ) : StyledShape {
 	override fun drawInternal(c: Context2d) {
 		c.fill(paint)
@@ -339,8 +341,9 @@ data class PolylineShape(
     val startCaps: LineCap,
     val endCaps: LineCap,
     val lineJoin: LineJoin,
-    val miterLimit: Double
-) : StyledShape {
+    val miterLimit: Double,
+    override val globalAlpha: Double = 1.0,
+    ) : StyledShape {
     private val tempBB = BoundsBuilder()
     private val tempRect = Rectangle()
 
@@ -407,7 +410,8 @@ class TextShape(
     val stroke: Paint?,
     val halign: HorizontalAlign = HorizontalAlign.LEFT,
     val valign: VerticalAlign = VerticalAlign.TOP,
-    override val transform: Matrix = Matrix()
+    override val transform: Matrix = Matrix(),
+    override val globalAlpha: Double = 1.0,
 ) : StyledShape {
     override val paint: Paint get() = fill ?: stroke ?: NonePaint
 

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/vector/ShapeBuilder.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/vector/ShapeBuilder.kt
@@ -23,15 +23,15 @@ open class ShapeBuilder(width: Int?, height: Int?) : Context2d(DummyRenderer), D
             shapes += FillShape(
                 path = state.path.clone(),
                 clip = state.clip?.clone(),
-                paint = state.fillStyle.transformed(state.transform),
-                transform = state.transform.clone()
+                paint = state.fillStyle.clone(),
+                transform = state.transform.clone(),
+                globalAlpha = state.globalAlpha,
             )
         } else {
             shapes += PolylineShape(
                 path = state.path.clone(),
                 clip = state.clip?.clone(),
-                paint = state.strokeStyle.transformed(state.transform),
-                //transform = Matrix(),
+                paint = state.strokeStyle.clone(),
                 transform = state.transform.clone(),
                 thickness = state.lineWidth,
                 pixelHinting = true,
@@ -39,10 +39,10 @@ open class ShapeBuilder(width: Int?, height: Int?) : Context2d(DummyRenderer), D
                 startCaps = state.startLineCap,
                 endCaps = state.endLineCap,
                 lineJoin = state.lineJoin,
-                miterLimit = state.miterLimit
+                miterLimit = state.miterLimit,
+                globalAlpha = state.globalAlpha,
             )
         }
-        super.rendererRender(state, fill)
     }
 
     override fun rendererRenderSystemText(state: State, font: Font?, fontSize: Double, text: String, x: Double, y: Double, fill: Boolean) {

--- a/korim/src/commonMain/kotlin/com/soywiz/korim/vector/format/SVG.kt
+++ b/korim/src/commonMain/kotlin/com/soywiz/korim/vector/format/SVG.kt
@@ -160,9 +160,9 @@ class SVG(val root: Xml, val warningProcessor: ((message: String) -> Unit)? = nu
             is GradientPaint -> {
                 val m = Matrix()
                 m.scale(bounds.width, bounds.height)
-                val out = res.applyMatrix(m)
-                //println(out)
-                out
+                res.applyMatrix(m).also {
+                    //println(it)
+                }
             }
             else -> {
                 res


### PR DESCRIPTION
This fixes bitmap and gradient fills in the experimental GPU vector rendering example.

Some work on https://github.com/korlibs/korge/issues/550

<img width="1392" alt="Screenshot 2022-03-29 at 21 50 40" src="https://user-images.githubusercontent.com/99644907/160695460-2779a50b-832c-48a7-b364-df8c28dca6b5.png">

Still misses:
* Clipping/masks
* Proper bounds for gpu shapes view
* Non-zero winding & strokes
* Antialiasing, either MSAA on render buffers or extra stencil tricks like nanovg that should give better performance