### PR TITLE
Utils for distributing views evenly across vertically/horizontally.

### DIFF
--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/util/util.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/util/util.kt
@@ -1,0 +1,106 @@
+package com.soywiz.korge.view.util
+
+import com.soywiz.korge.view.View
+
+
+// Distributes an iterable of views evenly across a provided bounding width.
+// The first view in the iterable will act as the ANCHOR VIEW which all other views will be
+// offset from.
+//
+// If you've used Google Slides/Microsoft Excel before, this is similar to evenly distributing a
+// bunch of selected shapes HORIZONTALLY.
+//
+// Unlike Slides, it does not use the right most view/shape, instead, you must provide the bounding
+// width beforehand.
+//
+// If you provide an iterable with a single view, then nothing will happen.
+fun distributeEvenlyHorizontally(views: Iterable<View>, boundingWidth: Double) {
+    val originView = views.first()
+
+    var remainingWidthToDistribute = boundingWidth
+    views.forEach { remainingWidthToDistribute -= it.scaledWidth }
+
+    val padding = remainingWidthToDistribute / (views.count() - 1)
+
+    var offset = 0.0
+    for (view in views) {
+        view.x = originView.x + offset
+        offset += view.scaledWidth + padding
+    }
+}
+
+// Same as `distributeEvenlyHorizontally(views, boundingWidth)`, but calculates the `boundingWidth`
+// beforehand by iterating through all the views and calculating the highest difference between
+// the first view and the right of the other views.
+//
+// Note that the FIRST VIEW in the iterable will be the ORIGIN VIEW that other views will be
+// offset from.
+//
+// Diagram:
+// (L,0)                       (K,0)
+//   │                           │
+//   ▼                           ▼
+//   ┌────────┐┌─────┐   ┌───────┐
+//   │1st view││     │...│       │
+//   └────────┘└─────┘   └───────┘
+// boundingWidth = K - L
+fun distributeEvenlyHorizontally(views: Iterable<View>) {
+    val originView = views.first()
+    val rightMostX = views.maxOf {
+        it.x + it.scaledWidth
+    }
+    distributeEvenlyHorizontally(views, rightMostX - originView.x)
+}
+
+// Distributes an iterable of views evenly across a provided bounding height.
+// The first view in the iterable will act as the ANCHOR VIEW which all other views will be
+// offset from.
+//
+// If you've used Google Slides/Microsoft Excel before, this is similar to evenly distributing a
+// bunch of selected shapes VERTICALLY.
+//
+// Unlike Slides, it does not use the bottom most view/shape, instead, you must provide the bounding
+// height beforehand.
+//
+// If you provide an iterable with a single view, then nothing will happen.
+fun distributeEvenlyVertically(views: Iterable<View>, boundingHeight: Double) {
+    val originView = views.first()
+
+    var remainingHeightToDistribute = boundingHeight
+    views.forEach { remainingHeightToDistribute -= it.scaledHeight }
+
+    val padding = remainingHeightToDistribute / (views.count() - 1)
+
+    var offset = 0.0
+    for (view in views) {
+        view.y = originView.y + offset
+        offset += view.scaledHeight + padding
+    }
+}
+
+// Same as `distributeEvenlyVertically(views, boundingHeight)`, but calculates the `boundingHeight`
+// beforehand by iterating through all the views and calculating the highest difference between
+// the first view and the bottom of the other views.
+//
+// Note that the FIRST VIEW in the iterable will be the ORIGIN VIEW that other views will be
+// offset from.
+//
+// Diagram:
+// (0,L)──►┌────────┐
+//         │1st view│
+//         └────────┘
+//         ┌────────┐
+//         │        │
+//         └────────┘
+//           ...
+//         ┌────────┐
+//         │        │
+// (0,K)──►└────────┘
+// boundingHeight = K - L
+fun distributeEvenlyVertically(views: Iterable<View>) {
+    val originView = views.first()
+    val bottomMostY = views.maxOf {
+        it.y + it.scaledHeight
+    }
+    distributeEvenlyVertically(views, bottomMostY - originView.y)
+}

--- a/korge/src/commonTest/kotlin/com/soywiz/korge/view/util/UtilTest.kt
+++ b/korge/src/commonTest/kotlin/com/soywiz/korge/view/util/UtilTest.kt
@@ -1,0 +1,360 @@
+package com.soywiz.korge.view.util
+
+import com.soywiz.korge.view.SolidRect
+import com.soywiz.korma.math.isAlmostEquals
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+internal class UtilTest {
+    @Test
+    fun distributeEvenlyHorizontally_singleViewProvidedResultsInNoChange() {
+        val rect1 = SolidRect(100.0, 100.0)
+
+        assertTrue {
+            rect1.x.isAlmostEquals(0.0)
+        }
+
+        distributeEvenlyHorizontally(listOf(rect1), 300.0)
+
+        assertTrue {
+            rect1.x.isAlmostEquals(0.0)
+        }
+    }
+
+    @Test
+    fun distributeEvenlyHorizontally_multipleViewsDistributesCorrectly1() {
+        val rect1 = SolidRect(100.0, 100.0)
+        val rect2 = SolidRect(100.0, 100.0)
+
+        assertTrue {
+            rect1.x.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect2.x.isAlmostEquals(0.0)
+        }
+
+        distributeEvenlyHorizontally(listOf(rect1, rect2), 300.0)
+
+        assertTrue {
+            rect1.x.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect2.x.isAlmostEquals(200.0)
+        }
+    }
+
+    @Test
+    fun distributeEvenlyHorizontally_multipleViewsDistributesCorrectly2() {
+        val rect1 = SolidRect(100.0, 100.0)
+        val rect2 = SolidRect(200.0, 200.0)
+        val rect3 = SolidRect(100.0, 100.0)
+
+        assertTrue {
+            rect1.x.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect2.x.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect3.x.isAlmostEquals(0.0)
+        }
+
+        distributeEvenlyHorizontally(listOf(rect1, rect2, rect3), 1000.0)
+
+        // Expected
+        // 100 (rect 1)
+        // 300 (padding)
+        // 200 (rect 2)
+        // 300 (padding)
+        // 100 (rect 3)
+
+        assertTrue {
+            rect1.x.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect2.x.isAlmostEquals(400.0)
+        }
+        assertTrue {
+            rect3.x.isAlmostEquals(900.0)
+        }
+    }
+
+    @Test
+    fun distributeEvenlyHorizontally_multipleViewsDistributesCorrectly3() {
+        val rect1 = SolidRect(100.0, 100.0)
+        val rect2 = SolidRect(200.0, 100.0)
+        val rect3 = SolidRect(100.0, 100.0)
+
+        assertTrue {
+            rect1.x.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect2.x.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect3.x.isAlmostEquals(0.0)
+        }
+
+        distributeEvenlyHorizontally(listOf(rect1, rect3, rect2), 1000.0)
+        // Expected
+        // 100 (rect 1)
+        // 300 (padding)
+        // 100 (rect 3)
+        // 300 (padding)
+        // 200 (rect 2)
+
+        assertTrue {
+            rect1.x.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect3.x.isAlmostEquals(400.0)
+        }
+        assertTrue {
+            rect2.x.isAlmostEquals(800.0)
+        }
+    }
+
+    @Test
+    fun distributeEvenlyHorizontally_boundingWidthCalculatedUsingRightMostView() {
+        val rect1 = SolidRect(100.0, 100.0)
+        val rect2 = SolidRect(200.0, 200.0)
+        val rect3 = SolidRect(100.0, 100.0).apply {
+            x = 900.0
+        }
+
+        assertTrue {
+            rect1.x.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect2.x.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect3.x.isAlmostEquals(900.0)
+        }
+
+        distributeEvenlyHorizontally(listOf(rect1, rect2, rect3), 1000.0)
+
+        // Expected
+        // 100 (rect 1)
+        // 300 (padding)
+        // 200 (rect 2)
+        // 300 (padding)
+        // 100 (rect 3)
+
+        assertTrue {
+            rect1.x.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect2.x.isAlmostEquals(400.0)
+        }
+        assertTrue {
+            rect3.x.isAlmostEquals(900.0)
+        }
+    }
+
+    @Test
+    fun distributeEvenlyHorizontally_offsetBasedOnFirstView() {
+        val rect1 = SolidRect(100.0, 100.0).apply {
+            x = 100.0
+        }
+        val rect2 = SolidRect(100.0, 100.0)
+
+        assertTrue {
+            rect1.x.isAlmostEquals(100.0)
+        }
+        assertTrue {
+            rect2.x.isAlmostEquals(0.0)
+        }
+
+        distributeEvenlyHorizontally(listOf(rect1, rect2), 300.0)
+
+        // Expected widths:
+        // 100 offset
+        // 100 (rect 1)
+        // 100 (padding)
+        // 100 (rect 2)
+
+        assertTrue {
+            rect1.x.isAlmostEquals(100.0)
+        }
+        assertTrue {
+            rect2.x.isAlmostEquals(300.0)
+        }
+    }
+
+    @Test
+    fun distributeEvenlyVertically_singleViewProvidedResultsInNoChange() {
+        val rect1 = SolidRect(100.0, 100.0)
+
+        assertTrue {
+            rect1.x.isAlmostEquals(0.0)
+        }
+
+        distributeEvenlyVertically(listOf(rect1), 300.0)
+
+        assertTrue {
+            rect1.y.isAlmostEquals(0.0)
+        }
+    }
+
+    @Test
+    fun distributeEvenlyVertically_multipleViewsDistributesCorrectly1() {
+        val rect1 = SolidRect(100.0, 100.0)
+        val rect2 = SolidRect(100.0, 100.0)
+
+        assertTrue {
+            rect1.y.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect2.y.isAlmostEquals(0.0)
+        }
+
+        distributeEvenlyVertically(listOf(rect1, rect2), 300.0)
+
+        assertTrue {
+            rect1.y.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect2.y.isAlmostEquals(200.0)
+        }
+    }
+
+    @Test
+    fun distributeEvenlyVertically_multipleViewsDistributesCorrectly2() {
+        val rect1 = SolidRect(100.0, 100.0)
+        val rect2 = SolidRect(200.0, 200.0)
+        val rect3 = SolidRect(100.0, 100.0)
+
+        assertTrue {
+            rect1.y.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect2.y.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect3.y.isAlmostEquals(0.0)
+        }
+
+        distributeEvenlyVertically(listOf(rect1, rect2, rect3), 1000.0)
+
+        // Expected
+        // 100 (rect 1)
+        // 300 (padding)
+        // 200 (rect 2)
+        // 300 (padding)
+        // 100 (rect 3)
+
+        assertTrue {
+            rect1.y.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect2.y.isAlmostEquals(400.0)
+        }
+        assertTrue {
+            rect3.y.isAlmostEquals(900.0)
+        }
+    }
+
+    @Test
+    fun distributeEvenlyVertically_multipleViewsDistributesCorrectly3() {
+        val rect1 = SolidRect(100.0, 100.0)
+        val rect2 = SolidRect(200.0, 200.0)
+        val rect3 = SolidRect(100.0, 100.0)
+
+        assertTrue {
+            rect1.y.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect2.y.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect3.y.isAlmostEquals(0.0)
+        }
+
+        distributeEvenlyVertically(listOf(rect1, rect3, rect2), 1000.0)
+        // Expected
+        // 100 (rect 1)
+        // 300 (padding)
+        // 100 (rect 3)
+        // 300 (padding)
+        // 200 (rect 2)
+
+        assertTrue {
+            rect1.y.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect3.y.isAlmostEquals(400.0)
+        }
+        assertTrue {
+            rect2.y.isAlmostEquals(800.0)
+        }
+    }
+
+    @Test
+    fun distributeEvenlyVertically_boundingHeightCalculatedUsingBottomMostView() {
+        val rect1 = SolidRect(100.0, 100.0)
+        val rect2 = SolidRect(200.0, 200.0)
+        val rect3 = SolidRect(100.0, 100.0).apply {
+            y = 900.0
+        }
+
+        assertTrue {
+            rect1.y.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect2.y.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect3.y.isAlmostEquals(900.0)
+        }
+
+        distributeEvenlyVertically(listOf(rect1, rect2, rect3))
+
+        // Expected
+        // 100 (rect 1)
+        // 300 (padding)
+        // 200 (rect 2)
+        // 300 (padding)
+        // 100 (rect 3)
+
+        assertTrue {
+            rect1.y.isAlmostEquals(0.0)
+        }
+        assertTrue {
+            rect2.y.isAlmostEquals(400.0)
+        }
+        assertTrue {
+            rect3.y.isAlmostEquals(900.0)
+        }
+    }
+
+    @Test
+    fun distributeEvenlyVertically_offsetBasedOnFirstView() {
+        val rect1 = SolidRect(100.0, 100.0).apply {
+            y = 100.0
+        }
+        val rect2 = SolidRect(100.0, 100.0)
+
+        assertTrue {
+            rect1.y.isAlmostEquals(100.0)
+        }
+        assertTrue {
+            rect2.y.isAlmostEquals(0.0)
+        }
+
+        distributeEvenlyVertically(listOf(rect1, rect2), 300.0)
+
+        // Expected widths:
+        // 100 offset
+        // 100 (rect 1)
+        // 100 (padding)
+        // 100 (rect 2)
+
+        assertTrue {
+            rect1.y.isAlmostEquals(100.0)
+        }
+        assertTrue {
+            rect2.y.isAlmostEquals(300.0)
+        }
+    }
+}


### PR DESCRIPTION
Real life example:

```
	val numbers = container {
		repeat(5) {
			val num = it + 1
			UIButton(BUTTON_WIDTH, BUTTON_HEIGHT, num.toString()).apply {
				onClick {
					if (checkBox.checked) {
						sudokuBoard.applyHint(num)
					} else {
						sudokuBoard.applyNumber(num)
					}
				}
			}.addTo(this)
		}
	}
	distributeEvenlyHorizontally(numbers.children, sudokuBoard.scaledWidth)
```

<img width="385" alt="image" src="https://user-images.githubusercontent.com/5054996/166184095-35295240-32b8-4b1d-80c1-4090cd8267d7.png">
