### PR TITLE
Support currentThreadId on external threads and workers on Kotlin/Native

### DIFF
--- a/korio/src/commonTest/kotlin/com/soywiz/korio/lang/ThreadIdTest.kt
+++ b/korio/src/commonTest/kotlin/com/soywiz/korio/lang/ThreadIdTest.kt
@@ -1,0 +1,11 @@
+package com.soywiz.korio.lang
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ThreadIdTest {
+    @Test
+    fun testCurrentThreadIdReturnsAlwaysTheSameValueOnTheSameThread() {
+        assertEquals(currentThreadId, currentThreadId)
+    }
+}

--- a/korio/src/darwinMain/kotlin/com/soywiz/korio/lang/ThreadDarwin.kt
+++ b/korio/src/darwinMain/kotlin/com/soywiz/korio/lang/ThreadDarwin.kt
@@ -1,0 +1,6 @@
+package com.soywiz.korio.lang
+
+import kotlinx.cinterop.objcPtr
+import platform.Foundation.NSThread
+
+actual val currentThreadId: Long get() = NSThread.currentThread.objcPtr().toLong()

--- a/korio/src/jsMain/kotlin/com/soywiz/korio/lang/ThreadJs.kt
+++ b/korio/src/jsMain/kotlin/com/soywiz/korio/lang/ThreadJs.kt
@@ -2,6 +2,7 @@ package com.soywiz.korio.lang
 
 import com.soywiz.klock.*
 
+// @TODO: Can we have different values when inside a worker? https://developer.mozilla.org/en-US/docs/Web/API/Worker
 actual val currentThreadId: Long get() = 1L
 
 actual fun Thread_sleep(time: Long) {

--- a/korio/src/jvmTest/kotlin/com/soywiz/korio/lang/ThreadIdJvmTest.kt
+++ b/korio/src/jvmTest/kotlin/com/soywiz/korio/lang/ThreadIdJvmTest.kt
@@ -1,0 +1,21 @@
+package com.soywiz.korio.lang
+
+import com.soywiz.korio.async.suspendTest
+import kotlinx.coroutines.CompletableDeferred
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class ThreadIdJvmTest {
+    @Test
+    fun testDifferentThreadIdInDifferentThread() = suspendTest {
+        val initialCurrentThreadId = currentThreadId
+        val threadCurrentThreadIdDeferred = CompletableDeferred<Long>()
+        Thread {
+            threadCurrentThreadIdDeferred.complete(currentThreadId)
+        }.also { it.start() }
+        assertNotEquals(initialCurrentThreadId, threadCurrentThreadIdDeferred.await())
+        val laterCurrentThreadId = currentThreadId
+        assertEquals(initialCurrentThreadId, laterCurrentThreadId)
+    }
+}

--- a/korio/src/linuxMain/kotlin/com/soywiz/korio/lang/ThreadLinux.kt
+++ b/korio/src/linuxMain/kotlin/com/soywiz/korio/lang/ThreadLinux.kt
@@ -1,0 +1,7 @@
+package com.soywiz.korio.lang
+
+import kotlinx.cinterop.convert
+import platform.linux.__NR_gettid
+import platform.posix.syscall
+
+actual val currentThreadId: Long get() = syscall(__NR_gettid.convert()).toLong()

--- a/korio/src/mingwMain/kotlin/com/soywiz/korio/lang/ThreadWin.kt
+++ b/korio/src/mingwMain/kotlin/com/soywiz/korio/lang/ThreadWin.kt
@@ -1,0 +1,5 @@
+package com.soywiz.korio.lang
+
+import platform.windows.GetCurrentThreadId
+
+actual val currentThreadId: Long get() = GetCurrentThreadId().toLong()

--- a/korio/src/nativeMain/kotlin/com/soywiz/korio/lang/ThreadNative.kt
+++ b/korio/src/nativeMain/kotlin/com/soywiz/korio/lang/ThreadNative.kt
@@ -2,8 +2,6 @@ package com.soywiz.korio.lang
 
 import kotlinx.cinterop.convert
 
-actual val currentThreadId: Long get() = 1L
-
 actual fun Thread_sleep(time: Long) {
 	platform.posix.usleep((time * 1000L).convert())
 }

--- a/korio/src/nativeTest/kotlin/com/soywiz/korio/lang/ThreadIdNativeTest.kt
+++ b/korio/src/nativeTest/kotlin/com/soywiz/korio/lang/ThreadIdNativeTest.kt
@@ -1,0 +1,20 @@
+package com.soywiz.korio.lang
+
+import kotlin.native.concurrent.TransferMode
+import kotlin.native.concurrent.Worker
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class ThreadIdNativeTest {
+    @Test
+    fun testWorkerHaveDifferentThreadId() {
+        val savedCurrentThreadId = currentThreadId
+        val worker = Worker.start()
+        val workerThreadId = worker.execute(TransferMode.SAFE, { Unit }, { currentThreadId })
+        val workerCurrentThreadId = workerThreadId.result
+        worker.requestTermination()
+        assertEquals(savedCurrentThreadId, currentThreadId)
+        assertNotEquals(workerCurrentThreadId, currentThreadId)
+    }
+}


### PR DESCRIPTION
Useful for debugging and be sure we are in the expected thread (for example to queue callback in the main EventLoop)

Split of https://github.com/korlibs/korge-next/pull/661