### PR TITLE
fix NPE in PolygonShape.set when no Vec2ArrayPool is given

### DIFF
--- a/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/shapes/PolygonShape.kt
+++ b/kbox2d/src/commonMain/kotlin/org/jbox2d/collision/shapes/PolygonShape.kt
@@ -128,10 +128,11 @@ class PolygonShape : Shape(ShapeType.POLYGON) {
         var n = MathUtils.min(num, Settings.maxPolygonVertices)
 
         // Perform welding and copy vertices into local buffer.
-        val ps = if (vecPool != null)
-            vecPool[Settings.maxPolygonVertices]
+        val ps : Array<Vec2?>
+        if (vecPool != null)
+            ps = vecPool[Settings.maxPolygonVertices] as Array<Vec2?>
         else
-            arrayOfNulls<Vec2>(Settings.maxPolygonVertices)
+            ps = arrayOfNulls<Vec2>(Settings.maxPolygonVertices)
         var tempCount = 0
         for (i in 0 until n) {
             val v = verts[i]
@@ -144,7 +145,7 @@ class PolygonShape : Shape(ShapeType.POLYGON) {
             }
 
             if (unique) {
-                ps[tempCount++]!!.set(v)
+                ps[tempCount++] = v
             }
         }
 
@@ -212,9 +213,6 @@ class PolygonShape : Shape(ShapeType.POLYGON) {
 
         // Copy vertices.
         for (i in 0 until count) {
-            if (vertices[i] == null) {
-                vertices[i] = Vec2()
-            }
             vertices[i].set(ps[hull[i]]!!)
         }
 

--- a/kbox2d/src/commonTest/kotlin/org/jbox2d/utests/PolygonShapeTest.kt
+++ b/kbox2d/src/commonTest/kotlin/org/jbox2d/utests/PolygonShapeTest.kt
@@ -1,0 +1,23 @@
+package org.jbox2d.utests
+
+import org.jbox2d.collision.shapes.PolygonShape
+import org.jbox2d.common.Vec2
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+
+class PolygonShapeTest {
+    @Test
+    fun test() {
+        val shape = PolygonShape()
+        val vertexArray = arrayOf(Vec2(1f, 1f), Vec2(1f, 0f), Vec2(0f, 0f))
+        shape.set(vertexArray, vertexArray.size)
+
+        assertEquals(shape.count, vertexArray.size)
+        (0 until shape.count).forEach {
+            assertTrue(vertexArray.contains(shape.getVertex(it)))
+        }
+    }
+}


### PR DESCRIPTION
Note that the cast on line 133 is necessary for Kotlin to figure out that the actual fix on line 147 is valid