### PR TITLE
Improve DSL marking to not be able to access views from buildVectorPath { } and derivates

### DIFF
--- a/korge-sandbox/src/commonMain/kotlin/MainClipping.kt
+++ b/korge-sandbox/src/commonMain/kotlin/MainClipping.kt
@@ -52,7 +52,7 @@ suspend fun Stage.mainClipping() {
 
     gpuShapeView({
         stroke(Colors.GREEN, lineWidth = 2.0) {
-            rect(0.0, 0.0, views.virtualWidthDouble, views.virtualHeightDouble)
+            rect(0.0, 0.0, this@mainClipping.views.virtualWidthDouble, this@mainClipping.views.virtualHeightDouble)
         }
     })
 

--- a/korge-sandbox/src/commonMain/kotlin/MainMasks.kt
+++ b/korge-sandbox/src/commonMain/kotlin/MainMasks.kt
@@ -51,6 +51,8 @@ suspend fun Stage.mainMasks() {
 
     val circle3 = circle(100.0, fill = fill1).centered
     launchImmediately {
+        val width = this.width
+        val height = this.height
         val path = buildPath { this.circle(width * 0.5, height * 0.5, 300.0) }
         animate(looped = true) {
             tween(circle3::pos[path], time = 2.seconds, easing = Easing.LINEAR)

--- a/korge-sandbox/src/commonMain/kotlin/MainStrokesExperiment.kt
+++ b/korge-sandbox/src/commonMain/kotlin/MainStrokesExperiment.kt
@@ -154,7 +154,7 @@ suspend fun Stage.mainStrokesExperiment2() {
                 }
 
                 PointArrayList().also {
-                    for (c in curves.curves) {
+                    for (c in curves.beziers) {
                         val bc = c as Bezier
                         it.add(bc.points.firstPoint())
                         it.add(bc.points.lastPoint())
@@ -167,7 +167,7 @@ suspend fun Stage.mainStrokesExperiment2() {
 
             }
             dbv2.pointsList = listOf(PointArrayList().also {
-                for (c in curves.curves) {
+                for (c in curves.beziers) {
                     val bc = c as Bezier
                     it.add(bc.points.firstPoint())
                     it.add(bc.points.lastPoint())
@@ -192,7 +192,7 @@ suspend fun Stage.mainStrokesExperiment() {
         //.applyTransform(Matrix().translate(-100, -200))
     val curves = path.getCurves()
 
-    println(curves.curves.joinToString("\n"))
+    println(curves.beziers.joinToString("\n"))
 
     val points = curves.toStrokePoints(10.0, mode = StrokePointsMode.SCALABLE_POS_NORMAL_WIDTH)
     Bezier(10.0, 10.0).inflections()

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/Korge.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/Korge.kt
@@ -36,7 +36,6 @@ import com.soywiz.korge.scene.Scene
 import com.soywiz.korge.scene.SceneContainer
 import com.soywiz.korge.stat.Stats
 import com.soywiz.korge.view.Stage
-import com.soywiz.korge.view.ViewDslMarker
 import com.soywiz.korge.view.Views
 import com.soywiz.korgw.CreateDefaultGameWindow
 import com.soywiz.korgw.GameWindow
@@ -167,7 +166,7 @@ object Korge {
         settingsFolder: String? = null,
         batchMaxQuads: Int = BatchBuilder2D.DEFAULT_BATCH_QUADS,
         multithreaded: Boolean? = null,
-        entry: @ViewDslMarker suspend Stage.() -> Unit
+        entry: suspend Stage.() -> Unit
 	) {
         if (!OS.isJsBrowser) {
             configureLoggerFromProperties(localCurrentDirVfs["klogger.properties"])

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/Stage.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/Stage.kt
@@ -8,6 +8,7 @@ import com.soywiz.korge.debug.uiCollapsibleSection
 import com.soywiz.korge.debug.uiEditableValue
 import com.soywiz.korge.render.RenderContext
 import com.soywiz.korio.resources.ResourcesContainer
+import com.soywiz.korma.annotations.RootViewDslMarker
 import com.soywiz.korma.geom.Point
 import com.soywiz.korma.geom.Rectangle
 import com.soywiz.korma.geom.setTo
@@ -17,6 +18,7 @@ import kotlinx.coroutines.CoroutineScope
 /**
  * Singleton root [View] and [Container] that contains a reference to the [Views] singleton and doesn't have any parent.
  */
+@RootViewDslMarker
 class Stage(override val views: Views) : FixedSizeContainer()
     , View.Reference
     , CoroutineScope by views

--- a/korge/src/commonMain/kotlin/com/soywiz/korge/view/View.kt
+++ b/korge/src/commonMain/kotlin/com/soywiz/korge/view/View.kt
@@ -2102,7 +2102,7 @@ fun <T : View> T.alpha(alpha: Double): T {
 fun <T : View> T.alpha(alpha: Float): T = alpha(alpha.toDouble())
 fun <T : View> T.alpha(alpha: Int): T = alpha(alpha.toDouble())
 
-@Target(AnnotationTarget.TYPE, AnnotationTarget.CLASS) annotation class ViewDslMarker
+typealias ViewDslMarker = com.soywiz.korma.annotations.ViewDslMarker
 // @TODO: This causes issues having to put some explicit this@ when it shouldn't be required
 //typealias ViewDslMarker = KorDslMarker
 

--- a/korge/src/commonTest/kotlin/com/soywiz/korge/view/ViewsTest.kt
+++ b/korge/src/commonTest/kotlin/com/soywiz/korge/view/ViewsTest.kt
@@ -423,7 +423,7 @@ class ViewsTest : ViewsForTesting() {
                 this.addEventComponent {
                     log.add("SolidRect1:${it::class.portableSimpleName}")
                     if (it is MyEvent) {
-                        addChildAt(SolidRect(200, 200).apply {
+                        this@container.addChildAt(SolidRect(200, 200).apply {
                             this.addEventComponent {
                                 log.add("SolidRect2:${it::class.portableSimpleName}")
                             }

--- a/korma/src/commonMain/kotlin/com/soywiz/korma/annotations/KorDslMarker.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/annotations/KorDslMarker.kt
@@ -1,5 +1,17 @@
 package com.soywiz.korma.annotations
 
 @DslMarker
-@Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.CLASS)
 annotation class KorDslMarker
+
+@Target(AnnotationTarget.TYPE, AnnotationTarget.CLASS)
+@DslMarker
+annotation class ViewDslMarker
+
+@Target(AnnotationTarget.TYPE, AnnotationTarget.CLASS)
+@DslMarker
+annotation class RootViewDslMarker
+
+@Target(AnnotationTarget.TYPE, AnnotationTarget.CLASS)
+@DslMarker
+annotation class VectorDslMarker

--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/vector/VectorBuilder.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/vector/VectorBuilder.kt
@@ -1,6 +1,9 @@
 package com.soywiz.korma.geom.vector
 
 import com.soywiz.korma.annotations.KorDslMarker
+import com.soywiz.korma.annotations.RootViewDslMarker
+import com.soywiz.korma.annotations.VectorDslMarker
+import com.soywiz.korma.annotations.ViewDslMarker
 import com.soywiz.korma.geom.Angle
 import com.soywiz.korma.geom.IPoint
 import com.soywiz.korma.geom.IPointArrayList
@@ -27,6 +30,9 @@ import kotlin.math.sin
 import kotlin.math.tan
 
 @KorDslMarker
+@ViewDslMarker
+@RootViewDslMarker
+@VectorDslMarker
 interface VectorBuilder {
     val totalPoints: Int
     val lastX: Double


### PR DESCRIPTION
Proper fix for https://github.com/korlibs/korge/issues/262

Based on the ideas from @kyay10 in https://discuss.kotlinlang.org/t/dsl-scope-limiting-with-two-different-dsls/18404/9

This finally fixes the annoying issue of being able to access `circle` and `roundRect` for view creation inside `buildVectorPath { }`