### PR TITLE
Fixes SHA512 having a wrong chunkSize/blockSize

### DIFF
--- a/krypto/src/commonMain/kotlin/com/soywiz/krypto/MD4.kt
+++ b/krypto/src/commonMain/kotlin/com/soywiz/krypto/MD4.kt
@@ -2,9 +2,9 @@ package com.soywiz.krypto
 
 import com.soywiz.krypto.internal.rotateLeft
 
-class MD4 : Hasher(chunkSize = 64, digestSize = 16) {
+class MD4 : Hasher(chunkSize = 64, digestSize = 16, "MD4") {
 
-    companion object : HasherFactory({ MD4() }) {
+    companion object : HasherFactory("MD4", { MD4() }) {
         private val S = intArrayOf(3, 7, 11, 19, 3, 5, 9, 13, 3, 9, 11, 15)
         private val R3 = listOf(0, 2, 1, 3)
     }

--- a/krypto/src/commonMain/kotlin/com/soywiz/krypto/MD5.kt
+++ b/krypto/src/commonMain/kotlin/com/soywiz/krypto/MD5.kt
@@ -4,8 +4,8 @@ import com.soywiz.krypto.internal.rotateLeft
 import kotlin.math.abs
 import kotlin.math.sin
 
-class MD5 : Hasher(chunkSize = 64, digestSize = 16) {
-    companion object : HasherFactory({ MD5() }) {
+class MD5 : Hasher(chunkSize = 64, digestSize = 16, "MD5") {
+    companion object : HasherFactory("MD5", { MD5() }) {
         private val S = intArrayOf(7, 12, 17, 22, 5, 9, 14, 20, 4, 11, 16, 23, 6, 10, 15, 21)
         private val T = IntArray(64) { ((1L shl 32) * abs(sin(1.0 + it))).toLong().toInt() }
     }

--- a/krypto/src/commonMain/kotlin/com/soywiz/krypto/PBKDF2.kt
+++ b/krypto/src/commonMain/kotlin/com/soywiz/krypto/PBKDF2.kt
@@ -13,28 +13,29 @@ class PBKDF2 {
         fun pbkdf2WithHmacSHA512(password: ByteArray, salt: ByteArray, iterationCount: Int, keySizeInBits: Int): Hash =
             pbkdf2(password, salt, iterationCount, keySizeInBits, SHA512())
 
-        private fun Int.toByteArray(): ByteArray {
-            return byteArrayOf(
-                (this shr 24 and 0xff).toByte(),
-                (this shr 16 and 0xff).toByte(),
-                (this shr 8 and 0xff).toByte(),
-                (this and 0xff).toByte()
-            )
+        private fun Int.toByteArray(out: ByteArray = ByteArray(4)): ByteArray {
+            out[0] = (this shr 24 and 0xff).toByte()
+            out[1] = (this shr 16 and 0xff).toByte()
+            out[2] = (this shr 8 and 0xff).toByte()
+            out[3] = (this and 0xff).toByte()
+            return out
         }
 
         fun pbkdf2(password: ByteArray, salt: ByteArray, iterationCount: Int, keySizeInBits: Int, hasher: Hasher): Hash {
             val hLen = hasher.digestSize
             val blockSize = keySizeInBits / hLen
             val outSize = keySizeInBits / 8
-            val result = ByteArray(outSize)
             var offset = 0
+            val result = ByteArray(outSize)
             val t = ByteArray(hLen)
+            val i32be = ByteArray(4)
+            val uv = ByteArray(salt.size + i32be.size)
             gen@ for (i in 1 .. blockSize) {
                 t.fill(0)
-                val i32be = i.toByteArray()
-                var u = ByteArray(salt.size + i32be.size)
-                arraycopy(salt, 0, u, 0, salt.size)
-                arraycopy(i32be, 0, u, salt.size, i32be.size)
+                i.toByteArray(i32be)
+                arraycopy(salt, 0, uv, 0, salt.size)
+                arraycopy(i32be, 0, uv, salt.size, i32be.size)
+                var u = uv
                 for (c in 1 .. iterationCount) {
                     u = HMAC.hmac(password, u, hasher).bytes
                     hasher.reset()

--- a/krypto/src/commonMain/kotlin/com/soywiz/krypto/PBKDF2.kt
+++ b/krypto/src/commonMain/kotlin/com/soywiz/krypto/PBKDF2.kt
@@ -4,13 +4,13 @@ import com.soywiz.krypto.internal.arraycopy
 
 class PBKDF2 {
     companion object {
-        fun pbkdf2WithHmacSHA1(password: ByteArray, salt: ByteArray, iterationCount: Int, keySizeInBits: Int) =
+        fun pbkdf2WithHmacSHA1(password: ByteArray, salt: ByteArray, iterationCount: Int, keySizeInBits: Int): Hash =
             pbkdf2(password, salt, iterationCount, keySizeInBits, SHA1())
 
-        fun pbkdf2WithHmacSHA256(password: ByteArray, salt: ByteArray, iterationCount: Int, keySizeInBits: Int) =
+        fun pbkdf2WithHmacSHA256(password: ByteArray, salt: ByteArray, iterationCount: Int, keySizeInBits: Int): Hash =
             pbkdf2(password, salt, iterationCount, keySizeInBits, SHA256())
 
-        fun pbkdf2WithHmacSHA512(password: ByteArray, salt: ByteArray, iterationCount: Int, keySizeInBits: Int) =
+        fun pbkdf2WithHmacSHA512(password: ByteArray, salt: ByteArray, iterationCount: Int, keySizeInBits: Int): Hash =
             pbkdf2(password, salt, iterationCount, keySizeInBits, SHA512())
 
         private fun Int.toByteArray(): ByteArray {
@@ -22,7 +22,7 @@ class PBKDF2 {
             )
         }
 
-        fun pbkdf2(password: ByteArray, salt: ByteArray, iterationCount: Int, keySizeInBits: Int, hasher: Hasher): ByteArray {
+        fun pbkdf2(password: ByteArray, salt: ByteArray, iterationCount: Int, keySizeInBits: Int, hasher: Hasher): Hash {
             val hLen = hasher.digestSize
             val blockSize = keySizeInBits / hLen
             val outSize = keySizeInBits / 8
@@ -49,7 +49,7 @@ class PBKDF2 {
                     }
                 }
             }
-            return result
+            return Hash(result)
         }
     }
 }

--- a/krypto/src/commonMain/kotlin/com/soywiz/krypto/SHA.kt
+++ b/krypto/src/commonMain/kotlin/com/soywiz/krypto/SHA.kt
@@ -1,10 +1,10 @@
 package com.soywiz.krypto
 
-abstract class SHA(chunkSize: Int, digestSize: Int) : Hasher(chunkSize, digestSize) {
+abstract class SHA(chunkSize: Int, digestSize: Int, name: String = "SHA${digestSize * 8}") : Hasher(chunkSize, digestSize, name) {
     override fun corePadding(totalWritten: Long): ByteArray {
         val tail = totalWritten % 64
-        val padding = (if (64 - tail >= 9) 64 - tail else 128 - tail)
-        val pad = ByteArray(padding.toInt()).apply { this[0] = 0x80.toByte() }
+        val padding = if (64 - tail >= 9) 64 - tail else 128 - tail
+        val pad = ByteArray(padding.toInt()).also { it[0] = 0x80.toByte() }
         val bits = (totalWritten * 8)
         for (i in 0 until 8) pad[pad.size - 1 - i] = ((bits ushr (8 * i)) and 0xFF).toByte()
         return pad

--- a/krypto/src/commonMain/kotlin/com/soywiz/krypto/SHA1.kt
+++ b/krypto/src/commonMain/kotlin/com/soywiz/krypto/SHA1.kt
@@ -4,8 +4,8 @@ import com.soywiz.krypto.internal.arraycopy
 import com.soywiz.krypto.internal.readS32_be
 import com.soywiz.krypto.internal.rotateLeft
 
-class SHA1 : SHA(chunkSize = 64, digestSize = 20) {
-    companion object : HasherFactory({ SHA1() }) {
+class SHA1 : SHA(chunkSize = 64, digestSize = 20, name = "SHA1") {
+    companion object : HasherFactory("SHA1", { SHA1() }) {
         private val H = intArrayOf(
             0x67452301L.toInt(),
             0xEFCDAB89L.toInt(),

--- a/krypto/src/commonMain/kotlin/com/soywiz/krypto/SHA256.kt
+++ b/krypto/src/commonMain/kotlin/com/soywiz/krypto/SHA256.kt
@@ -5,7 +5,7 @@ import com.soywiz.krypto.internal.readS32_be
 import com.soywiz.krypto.internal.rotateRight
 
 class SHA256 : SHA(chunkSize = 64, digestSize = 32) {
-    companion object : HasherFactory({ SHA256() }) {
+    companion object : HasherFactory("SHA256", { SHA256() }) {
         private val H = intArrayOf(
             0x6a09e667, -0x4498517b, 0x3c6ef372, -0x5ab00ac6,
             0x510e527f, -0x64fa9774, 0x1f83d9ab, 0x5be0cd19

--- a/krypto/src/commonMain/kotlin/com/soywiz/krypto/SHA512.kt
+++ b/krypto/src/commonMain/kotlin/com/soywiz/krypto/SHA512.kt
@@ -6,8 +6,8 @@ import com.soywiz.krypto.internal.arraycopy
 // https://git.suckless.org/sbase/file/sha512.h.html
 /* public domain sha512 implementation based on fips180-3 */
 @OptIn(ExperimentalUnsignedTypes::class)
-class SHA512 : SHA(chunkSize = 64, digestSize = 64) {
-    companion object : HasherFactory({ SHA512() }) {
+class SHA512 : SHA(chunkSize = 128, digestSize = 64) {
+    companion object : HasherFactory("SHA512", { SHA512() }) {
         private const val SHA512_DIGEST_LENGTH = 64
 
         private fun ror(n: ULong, k: Int): ULong = (n shr k) or (n shl (64 - k))
@@ -66,6 +66,7 @@ class SHA512 : SHA(chunkSize = 64, digestSize = 64) {
     // @TODO: The super update doesn't work with SHA512, do we have to fix something?
     override fun update(data: ByteArray, offset: Int, count: Int): Hasher {
         sha512_update(data.asUByteArray(), offset, count)
+        totalWritten += count
         return this
     }
 

--- a/krypto/src/commonTest/kotlin/com/soywiz/krypto/PBKDF2Test.kt
+++ b/krypto/src/commonTest/kotlin/com/soywiz/krypto/PBKDF2Test.kt
@@ -24,4 +24,16 @@ class PBKDF2Test {
         val v = PBKDF2.pbkdf2WithHmacSHA256(password, salt, iterationCount, keyLength)
         assertEquals("151e360d1a6d085395d6a79473edfbf3dbdbdc6ffadf2b27a255d87f7bc4d2d1", v.hex)
     }
+
+    @Test
+    fun pbkdf2WithHmacSHA512() {
+        val password = "password".encodeToByteArray()
+        val salt = ByteArray(12) { (it + 1).toByte() }
+        val iterationCount = 4096
+        val keyLength = 256
+        assertEquals(
+            PBKDF2.pbkdf2WithHmacSHA512(password, salt, iterationCount, keyLength).hex,
+            "77fec6ca97e3c15022b1c51a37cf05739e6a3c90b8c85518427ac5be6f8fa06d"
+        )
+    }
 }

--- a/krypto/src/jvmTest/kotlin/com/soywiz/krypto/PBKDF2JvmTest.kt
+++ b/krypto/src/jvmTest/kotlin/com/soywiz/krypto/PBKDF2JvmTest.kt
@@ -1,0 +1,86 @@
+package com.soywiz.krypto
+
+import org.junit.Test
+import java.security.MessageDigest
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
+import kotlin.test.assertEquals
+
+class PBKDF2JvmTest {
+    fun generateJVM(
+        kind: HasherFactory,
+        password: ByteArray = byteArrayOf(65, 66, 67, 68, 69, 70, 71, 72),
+        keyLength: Int = 256,
+        iterationCount: Int = 4096,
+        salt: ByteArray = ByteArray(12) { (it + 1).toByte() }
+    ): Hash {
+        return Hash(SecretKeyFactory.getInstance("PBKDF2WithHmac${kind.name}").generateSecret(
+            PBEKeySpec(password.map { it.toInt().toChar() }.toCharArray(), salt, iterationCount, keyLength)
+        ).encoded)
+    }
+
+    fun generateKrypto(
+        kind: HasherFactory,
+        password: ByteArray = byteArrayOf(65, 66, 67, 68, 69, 70, 71, 72),
+        keyLength: Int = 256,
+        iterationCount: Int = 4096,
+        salt: ByteArray = ByteArray(12) { (it + 1).toByte() }
+    ): Hash {
+        return PBKDF2.pbkdf2(password, salt, iterationCount, keyLength, kind())
+    }
+
+    fun checkAlgo(kind: HasherFactory) {
+        assertEquals(generateJVM(kind), generateKrypto(kind))
+    }
+
+    @Test
+    fun pbkdf2WithHmacSHA1() {
+        checkAlgo(SHA1)
+    }
+
+    @Test
+    fun pbkdf2WithHmacSHA256() {
+        checkAlgo(SHA256)
+    }
+
+    @Test
+    fun pbkdf2WithHmacSHA512() {
+        checkAlgo(SHA512)
+    }
+
+    @Test
+    fun pbkdf2WithHmacJavaSHA1() {
+        checkAlgo(JavaSHA.Factory(1))
+    }
+
+    @Test
+    fun pbkdf2WithHmacJavaSHA512() {
+        checkAlgo(JavaSHA.Factory(512))
+    }
+
+    @Test
+    fun pbkdf2WithHmacJavaSHA256() {
+        checkAlgo(JavaSHA.Factory(256))
+    }
+
+    class JavaSHA(
+        val size: Int,
+        val md: MessageDigest = MessageDigest.getInstance("SHA-$size")
+    ) : NonCoreHasher(if (size == 512) 128 else 64, md.digestLength, "SHA$size") {
+        class Factory(size: Int) : HasherFactory("SHA$size", { JavaSHA(size) })
+
+        override fun reset(): Hasher {
+            md.reset()
+            return this
+        }
+
+        override fun update(data: ByteArray, offset: Int, count: Int): Hasher {
+            md.update(data, offset, count)
+            return this
+        }
+
+        override fun digestOut(out: ByteArray) {
+            md.digest().copyInto(out, 0, 0, out.size)
+        }
+    }
+}


### PR DESCRIPTION
That should be 128 by…tes (1024 bits) instead of 64 bytes (512 bits) + Make PBKDF2 return a Hash instead

Fixes https://github.com/korlibs/korge-next/issues/705